### PR TITLE
Fix: Ensure game board and pieces are drawn correctly

### DIFF
--- a/src/phaser/MainBoardScene.ts
+++ b/src/phaser/MainBoardScene.ts
@@ -147,7 +147,7 @@ export default class MainBoardScene extends Phaser.Scene {
     const oldState = this.gameState;
     this.gameState = newState;
 
-    if (!this.boardIsDrawn && this.gameState.players.length > 0 && this.gameState.boardLayout) {
+    if (!this.boardIsDrawn && this.gameState.players && this.gameState.players.length > 0 && this.gameState.boardLayout && this.gameState.boardLayout.length > 0) {
       console.log('[Phaser] Drawing board for the first time.');
       this.drawBoard(this.gameState.boardLayout);
       this.initializePlayers(this.gameState.players);


### PR DESCRIPTION
The previous logic could prematurely mark the board as drawn (`boardIsDrawn = true`) even if the initial game state lacked player or board layout data. This prevented the board and pieces from being rendered when the data eventually arrived.

This commit modifies the condition in `MainBoardScene.updateGameState` to check that both `players` and `boardLayout` arrays are present and non-empty before attempting the initial draw and setting the `boardIsDrawn` flag. This ensures that the board and pieces will be rendered correctly as soon as their data is available.