### PR TITLE
Fix: Resolve multiple import errors

### DIFF
--- a/src/phaser/MainBoardScene.ts
+++ b/src/phaser/MainBoardScene.ts
@@ -3,7 +3,7 @@
 import Phaser from 'phaser';
 import type { Game, Player } from '../types/game'; // Ensure this matches the updated structure
 import { SPELL_DEFINITIONS, SpellType, type SpellId } from '../data/spells'; // Import SpellType and SPELL_DEFINITIONS
-import soundService from '../../services/soundService'; // Import SoundService
+import soundService from '../services/soundService'; // Import SoundService
 
 // Updated TileConfig to match src/types/game.ts
 interface TileConfig {

--- a/src/phaser/game.ts
+++ b/src/phaser/game.ts
@@ -1,0 +1,25 @@
+import Phaser from 'phaser';
+
+// You might want to import your scenes here if they are ready
+// import MainBoardScene from './MainBoardScene';
+// import HubScene from './HubScene';
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  width: 800,
+  height: 600,
+  physics: {
+    default: 'arcade',
+    arcade: {
+      gravity: { y: 0 },
+      debug: false
+    }
+  },
+  // Initially, you might not have a scene, or you can use a placeholder
+  // scene: [MainBoardScene, HubScene] // Example if you have scenes
+  scene: undefined // Or handle scene management dynamically
+};
+
+const game = new Phaser.Game(config);
+
+export { game };


### PR DESCRIPTION
This commit addresses the following import/module resolution issues:

1.  Created `src/phaser/game.ts` with a basic Phaser game configuration to resolve the missing module error in `src/App.tsx`.
2.  Installed the `howler` library and its TypeScript type definitions (`@types/howler`) to fix import errors in `src/services/soundService.ts`.
3.  Corrected the relative import path for `soundService` in `src/phaser/MainBoardScene.ts` from `../../services/soundService` to `../services/soundService`.

The Vite development server (`npm run dev`) now starts without any initial import-related errors.