### PR TITLE
Fix: Resolve CORS errors by using local assets in HubScene

### DIFF
--- a/src/phaser/HubScene.ts
+++ b/src/phaser/HubScene.ts
@@ -37,11 +37,11 @@ export class HubScene extends Phaser.Scene {
   }
 
   preload() {
-    this.load.image('hub_tiles', 'http://labs.phaser.io/assets/textures/grass.png');
+    this.load.image('hub_tiles', 'assets/korean-game-board.png');
     this.load.image('player_avatar', 'assets/player.png');
     this.load.image('other_player_avatar', 'assets/player.png'); // Can be a different asset or tinted
-    this.load.image('game_portal', 'http://labs.phaser.io/assets/sprites/orb-red.png'); // Placeholder for portal/NPC
-    this.load.image('guild_panel', 'http://labs.phaser.io/assets/sprites/orb-green.png'); // Placeholder for guild panel
+    this.load.image('game_portal', 'assets/event.png'); // Placeholder for portal/NPC
+    this.load.image('guild_panel', 'assets/tiles/tile_MANA_GAIN.png'); // Placeholder for guild panel
   }
 
   create() {


### PR DESCRIPTION
The HubScene was attempting to load image assets from http://labs.phaser.io, causing CORS policy errors.

This change updates the `preload` method in `src/phaser/HubScene.ts` to use local asset paths instead.

The following substitutions were made due to the original assets not being found:
- 'hub_tiles' (grass.png) now uses 'assets/korean-game-board.png'
- 'game_portal' (orb-red.png) now uses 'assets/event.png'
- 'guild_panel' (orb-green.png) now uses 'assets/tiles/tile_MANA_GAIN.png'

This resolves the immediate CORS errors. I have informed you about these substitutions and you may update the paths if different local assets are intended.