### PR TITLE
Feat: Revitalize Hub based on your feedback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -508,3 +508,13 @@ button.secondary:active:not(:disabled), .logout-button:active:not(:disabled) {
   padding: var(--spacing-unit) calc(var(--spacing-unit) * 1.5); /* Smaller padding for table buttons */
   font-size: var(--font-size-sm);
 }
+
+/* Styles for the HubPage container to enable full screen Phaser canvas */
+.hub-page-container,
+#phaser-hub-container {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden; /* Ensure no scrollbars from the container itself */
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,11 @@
 /* src/index.css */
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden; /* Prevent scrollbars if Phaser canvas slightly overflows */
+}
+
 :root {
   /* Colors */
   --primary-color: #007bff; /* Example: Blue */
@@ -48,6 +55,10 @@ body {
   line-height: var(--line-height-base);
   color: var(--text-color); /* Default text color */
   background-color: var(--light-bg-color); /* Default background */
+}
+
+#root { /* The div React mounts into */
+  height: 100%;
 }
 
 /* General styling for links */

--- a/src/pages/HubPage.tsx
+++ b/src/pages/HubPage.tsx
@@ -17,6 +17,12 @@ const HubPage: React.FC = () => {
         width: 800,
         height: 600,
         parent: gameRef.current,
+        scale: {
+          mode: Phaser.Scale.FIT,
+          autoCenter: Phaser.Scale.CENTER_BOTH,
+          width: '100%',
+          height: '100%'
+        },
         scene: [HubScene], // Add HubScene here
         physics: {
           default: 'arcade',
@@ -56,7 +62,7 @@ const HubPage: React.FC = () => {
   }, []); // Empty dependency array means this runs once on mount and cleanup on unmount
 
   return (
-    <div style={{ position: 'relative' }}> {/* Added for potential stacking context if needed */}
+    <div className="hub-page-container" style={{ position: 'relative' }}> {/* Added for potential stacking context if needed */}
       <div ref={gameRef} id="phaser-hub-container" />
       <GameLobbyModal
         isOpen={isGameLobbyModalOpen}

--- a/src/phaser/HubScene.ts
+++ b/src/phaser/HubScene.ts
@@ -54,7 +54,7 @@ export class HubScene extends Phaser.Scene {
     // Setup player
     if (this.textures.exists('player_avatar')) {
       this.player = this.add.sprite(this.cameras.main.width / 2, this.cameras.main.height / 2, 'player_avatar') as any;
-      this.player.setScale(2);
+      this.player.setScale(1);
     } else {
       // Fallback for player avatar (as before)
       console.error('Player avatar texture not found!');
@@ -92,9 +92,29 @@ export class HubScene extends Phaser.Scene {
     const portalX = this.cameras.main.width - 100; // Example position
     const portalY = this.cameras.main.height / 2;
     const gamePortal = this.add.sprite(portalX, portalY, 'game_portal').setInteractive();
+    // Ensure gamePortal fits within 128x128px, maintaining aspect ratio
+    gamePortal.setOrigin(0.5, 0.5); // Ensure scaling is from center if not already
+    const maxDimPortal = 128;
+    if (gamePortal.width > maxDimPortal || gamePortal.height > maxDimPortal) {
+        const scalePortal = maxDimPortal / Math.max(gamePortal.width, gamePortal.height);
+        gamePortal.setScale(scalePortal);
+    }
+    // No else needed: if smaller than 128x128, it will display at its native size (scale 1 by default)
     gamePortal.on('pointerdown', () => {
       console.log('Game portal clicked');
       this.game.events.emit('openGameLobbyModal');
+    });
+
+    // Add pulsing animation to gamePortal
+    const baseScalePortal = gamePortal.scaleX; // Get current scale
+    this.tweens.add({
+      targets: gamePortal,
+      scaleX: baseScalePortal * 1.08, // Pulse by 8%
+      scaleY: baseScalePortal * 1.08,
+      duration: 800,                 // Duration for one pulse
+      yoyo: true,                    // Reverse the animation
+      repeat: -1,                  // Loop indefinitely
+      ease: 'Sine.easeInOut'         // Smooth easing function
     });
 
     // Handle scene shutdown to remove player from Firestore
@@ -104,9 +124,29 @@ export class HubScene extends Phaser.Scene {
     const guildPanelX = 100; // Example position
     const guildPanelY = this.cameras.main.height / 2;
     const guildPanelSprite = this.add.sprite(guildPanelX, guildPanelY, 'guild_panel').setInteractive();
+    // Ensure guildPanelSprite fits within 128x128px, maintaining aspect ratio
+    guildPanelSprite.setOrigin(0.5, 0.5); // Ensure scaling is from center
+    const maxDimPanel = 128;
+    if (guildPanelSprite.width > maxDimPanel || guildPanelSprite.height > maxDimPanel) {
+        const scalePanel = maxDimPanel / Math.max(guildPanelSprite.width, guildPanelSprite.height);
+        guildPanelSprite.setScale(scalePanel);
+    }
+    // No else needed: if smaller than 128x128, it will display at its native size (scale 1 by default)
     guildPanelSprite.on('pointerdown', () => {
       console.log('Guild panel clicked');
       this.game.events.emit('openGuildManagementModal');
+    });
+
+    // Add pulsing animation to guildPanelSprite
+    const baseScaleGuildPanel = guildPanelSprite.scaleX; // Get current scale
+    this.tweens.add({
+      targets: guildPanelSprite,
+      scaleX: baseScaleGuildPanel * 1.08, // Pulse by 8%
+      scaleY: baseScaleGuildPanel * 1.08,
+      duration: 800,                    // Duration for one pulse
+      yoyo: true,                       // Reverse the animation
+      repeat: -1,                     // Loop indefinitely
+      ease: 'Sine.easeInOut'            // Smooth easing function
     });
   }
 
@@ -146,7 +186,7 @@ export class HubScene extends Phaser.Scene {
         if (change.type === 'added' || change.type === 'modified') {
           if (!remotePlayerSprite) {
             remotePlayerSprite = this.add.sprite(playerData.x, playerData.y, 'other_player_avatar') as any;
-            remotePlayerSprite.setScale(1.5); // Slightly different scale for others
+            remotePlayerSprite.setScale(1); // Slightly different scale for others
             (remotePlayerSprite as any).uid = playerUid; // Store UID on the sprite
             this.otherPlayers.add(remotePlayerSprite);
             this.physics.world.enable(remotePlayerSprite); // Enable physics for basic movement


### PR DESCRIPTION
This commit implements a three-axis plan to enhance the Hub experience:

1.  **Axe 1: Full-Screen Experience:**
    *   Modified `src/pages/HubPage.tsx` to configure Phaser with `Scale.FIT` mode, allowing the Hub to fill the browser window.
    *   Adjusted CSS in `src/index.css` and `src/App.css` to ensure `html`, `body`, `#root`, and the Phaser container elements in HubPage take full height and width.

2.  **Axe 2: Asset Scale Mastery:**
    *   In `src/phaser/HubScene.ts`:
        *   Player sprites (`player_avatar`, `other_player_avatar`) are now set to `setScale(1)` to respect their native (assumed 32x32) size.
        *   Decor elements (`game_portal`, `guild_panel`) are now dynamically scaled to fit within a 128x128 pixel bounding box if their native size is larger, maintaining aspect ratio.

3.  **Axe 3: Living Scenography:**
    *   In `src/phaser/HubScene.ts`:
        *   Added subtle pulsing tween animations (scale oscillation) to the interactive `game_portal` and `guild_panel` sprites to make them more noticeable and inviting.

These changes aim to create a more immersive, visually coherent, and dynamic Hub environment as per your design direction.