### PR TITLE
feat: Implement UI component transitions for GamePage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -462,6 +462,46 @@ button.secondary:active:not(:disabled), .logout-button:active:not(:disabled) {
   /* width: 100%; */ /* If using position: absolute, ensure width is maintained */
 }
 
+/* Player Controls (Spellbook & GameControls) Transition Styles */
+.player-controls-transition-enter {
+  opacity: 0;
+  transform: translateY(20px);
+}
+.player-controls-transition-enter-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 300ms ease-out, transform 300ms ease-out;
+}
+.player-controls-transition-exit {
+  opacity: 1;
+  transform: translateY(0);
+}
+.player-controls-transition-exit-active {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 300ms ease-in, transform 300ms ease-in;
+}
+
+/* Opponent Indicator Transition Styles */
+.opponent-indicator-transition-enter {
+  opacity: 0;
+  transform: translateY(20px);
+}
+.opponent-indicator-transition-enter-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 300ms ease-out, transform 300ms ease-out;
+}
+.opponent-indicator-transition-exit {
+  opacity: 1;
+  transform: translateY(0);
+}
+.opponent-indicator-transition-exit-active {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 300ms ease-in, transform 300ms ease-in;
+}
+
 /* Success Message Styles */
 .success-message {
   color: var(--success-color);


### PR DESCRIPTION
Adds fade and slide-up animations for the appearance and disappearance of Spellbook, GameControls, and OpponentTurnIndicator components on the GamePage.

Utilizes react-transition-group's CSSTransition to achieve these effects, enhancing the user experience with smoother visual feedback.

- Spellbook and GameControls are animated together under the 'player-controls-transition' class.
- OpponentTurnIndicator is animated with 'opponent-indicator-transition'.
- All transitions have a duration of 300ms and use opacity and translateY transformations.
- Components are unmounted on exit for performance.