### PR TITLE
feat(hub): implement daily challenge modal and launch logic

### DIFF
--- a/src/components/DailyChallengeModal.css
+++ b/src/components/DailyChallengeModal.css
@@ -1,0 +1,69 @@
+/* src/components/DailyChallengeModal.css */
+/* Styles for DailyChallengeModal, assuming .modal-overlay and .modal-content are globally available or defined elsewhere (e.g. in GameLobbyModal.css or a global modal.css) */
+
+.daily-challenge-modal-content {
+  /* Specific styles for the content area if needed, or rely on .modal-content */
+  text-align: center;
+}
+
+.daily-challenge-modal-content h2 {
+  margin-top: 0;
+  margin-bottom: calc(var(--spacing-unit) * 2); /* 16px */
+  font-size: var(--font-size-xl, 1.5em);
+  color: var(--primary-color); /* Using primary color for the main title */
+}
+
+.daily-challenge-modal-content h3 {
+  margin-top: calc(var(--spacing-unit) * 3); /* 24px */
+  margin-bottom: calc(var(--spacing-unit) * 1); /* 8px */
+  font-size: var(--font-size-lg, 1.25em);
+  color: var(--text-color);
+}
+
+.daily-challenge-modal-content p {
+  margin-bottom: calc(var(--spacing-unit) * 1.5); /* 12px */
+  font-size: var(--font-size-base, 1em);
+  line-height: var(--line-height-base, 1.6);
+}
+
+.daily-challenge-modal-content p strong {
+  color: var(--secondary-color); /* Highlight for labels */
+}
+
+.daily-challenge-modal-buttons {
+  margin-top: calc(var(--spacing-unit) * 3); /* 24px */
+  display: flex;
+  justify-content: center; /* Center buttons */
+  gap: calc(var(--spacing-unit) * 2); /* Space between buttons */
+}
+
+/* Assuming a global .button-base or similar might exist, or style them directly */
+.daily-challenge-modal-buttons button {
+  padding: calc(var(--spacing-unit) * 1.5) calc(var(--spacing-unit) * 3); /* 12px 24px */
+  font-size: var(--font-size-base);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, transform 0.1s ease;
+}
+
+.daily-challenge-modal-buttons button.launch-button {
+  background-color: var(--primary-color);
+  color: var(--text-color-light);
+  border: 1px solid var(--primary-color);
+}
+
+.daily-challenge-modal-buttons button.launch-button:hover {
+  background-color: color-mix(in srgb, var(--primary-color) 85%, black);
+  transform: translateY(-1px);
+}
+
+.daily-challenge-modal-buttons button.close-button {
+  background-color: var(--secondary-bg-color, #6c757d); /* Fallback if secondary-bg-color not defined */
+  color: var(--text-color-light);
+  border: 1px solid var(--secondary-bg-color, #6c757d);
+}
+
+.daily-challenge-modal-buttons button.close-button:hover {
+  background-color: color-mix(in srgb, var(--secondary-bg-color, #6c757d) 85%, black);
+  transform: translateY(-1px);
+}

--- a/src/components/DailyChallengeModal.tsx
+++ b/src/components/DailyChallengeModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import './DailyChallengeModal.css';
+
+interface DailyChallengeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLaunch: () => void;
+  challenge: {
+    title: string;
+    objective: string;
+    reward: string;
+  };
+}
+
+const DailyChallengeModal: React.FC<DailyChallengeModalProps> = ({
+  isOpen,
+  onClose,
+  onLaunch,
+  challenge,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <h2>Défi du Jour</h2>
+        <h3>{challenge.title}</h3>
+        <p><strong>Objectif :</strong> {challenge.objective}</p>
+        <p><strong>Récompense :</strong> {challenge.reward}</p>
+        <div className="daily-challenge-modal-buttons">
+          <button onClick={onLaunch} className="launch-button">Lancer le Défi</button>
+          <button onClick={onClose} className="close-button">Fermer</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DailyChallengeModal;

--- a/src/phaser/HubScene.ts
+++ b/src/phaser/HubScene.ts
@@ -58,6 +58,7 @@ export default class HubScene extends Phaser.Scene {
     this.load.image("other_player_avatar", "assets/player_32.png"); // Can be a different asset or tinted
     this.load.image("game_portal", "assets/game_portal.jpeg"); // Placeholder for portal/NPC
     this.load.image("guild_panel", "assets/guild_panel.jpeg"); // Placeholder for guild panel
+    this.load.image("daily_challenge_board", "assets/game_portal.jpeg"); // Placeholder for daily challenge board (using game_portal asset for now)
     this.load.image("transparent", "assets/effects/transparent.png");
   }
 
@@ -170,6 +171,21 @@ export default class HubScene extends Phaser.Scene {
       this.game.events.emit("openGuildManagementModal");
     });
 
+    // Add Daily Challenge Board
+    const dailyChallengeBoard = this.triggerZones
+      .create(
+        this.cameras.main.width / 2, // Centered horizontally
+        100, // Positioned towards the top
+        "daily_challenge_board",
+      )
+      .setScale(0.1) // Adjust scale as needed
+      .setInteractive()
+      .refreshBody();
+
+    dailyChallengeBoard.on("pointerdown", () => {
+      console.log("Daily challenge board clicked");
+      this.game.events.emit("openDailyChallengeModal");
+    });
 
 
     // Add overlap physics for guildPanel


### PR DESCRIPTION
- Add DailyChallengeModal.tsx React component to display daily challenge information (title, objective, reward) and actions.
- Integrate DailyChallengeModal into HubPage.tsx, managing its visibility via Phaser events.
- Add an interactive element (placeholder "Daily Challenge Board") in HubScene.ts that triggers the modal display.
- Implement logic in HubPage.tsx to stop HubScene music and scene, then start the appropriate mini-game scene (HangeulTyphoonScene as example) with challenge-specific parameters when the user launches the challenge.
- Ensure HangeulTyphoonScene is added to Phaser game config to allow it to be started from HubPage.
- Update HangeulTyphoonScene to correctly interpret 'gameMode' from passed parameters for challenge display.