### PR TITLE
Fix: Resolve numerous TypeScript errors across codebase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import './App.css';
 import ToastContainer from './components/ToastNotification';
 import { useToasts } from './contexts/ToastContext';
 import soundService, { SOUND_DEFINITIONS } from './services/soundService';
-import { getSyncQueueItems, deleteFromSyncQueue, SyncQueueItem } from './services/dbService'; // Import IndexedDB sync functions
+import { getSyncQueueItems, deleteFromSyncQueue } from './services/dbService'; // Import IndexedDB sync functions, removed SyncQueueItem
 
 function App() {
   const { t, i18n } = useTranslation();
@@ -44,14 +44,14 @@ function App() {
     }
 
     setIsSyncing(true);
-    addToast({ type: 'info', message: 'Synchronisation du progrès hors-ligne en cours...' });
+    addToast('Synchronisation du progrès hors-ligne en cours...', 'info');
     console.log(`Sync: Processing sync queue for user ${currentUser.uid}`);
 
     try {
       const itemsToSync = await getSyncQueueItems(currentUser.uid);
       if (itemsToSync.length === 0) {
         console.log("Sync: Queue is empty.");
-        addToast({ type: 'info', message: 'Aucun progrès local à synchroniser.' });
+        addToast('Aucun progrès local à synchroniser.', 'info');
         setIsSyncing(false);
         return;
       }
@@ -74,20 +74,20 @@ function App() {
       }
 
       if (successCount > 0) {
-        addToast({ type: 'success', message: `${successCount} élément(s) de progrès synchronisé(s) avec succès.` });
+        addToast(`${successCount} élément(s) de progrès synchronisé(s) avec succès.`, 'success');
       }
       if (failureCount > 0) {
-        addToast({ type: 'warning', message: `${failureCount} élément(s) n'ont pas pu être synchronisés. Ils seront réessayés plus tard.` });
+        addToast(`${failureCount} élément(s) n'ont pas pu être synchronisés. Ils seront réessayés plus tard.`, 'warning');
       } else if (successCount === 0 && failureCount === 0 && itemsToSync.length > 0) {
         // This case should ideally not happen if itemsToSync.length > 0
-        addToast({ type: 'info', message: 'File de synchronisation traitée, aucun changement majeur.' });
+        addToast('File de synchronisation traitée, aucun changement majeur.', 'info');
       }
        // TODO: Consider triggering a refresh of runesToReviewCount in GrimoireVivant
        // This might require a global state or event bus, or simply rely on the next Firestore snapshot.
 
     } catch (error) {
       console.error("Sync: Error processing sync queue:", error);
-      addToast({ type: 'error', message: 'Erreur majeure lors de la synchronisation du progrès local.' });
+      addToast('Erreur majeure lors de la synchronisation du progrès local.', 'error');
     } finally {
       setIsSyncing(false);
       console.log("Sync: Queue processing finished.");
@@ -133,13 +133,13 @@ function App() {
 
     // Listen for online event to trigger sync
     const handleOnline = () => {
-      addToast({ type: 'info', message: 'Connexion internet rétablie.' });
+      addToast('Connexion internet rétablie.', 'info');
       if (user && !user.isAnonymous) { // Ensure user is logged in
         processSyncQueue(user);
       }
     };
     const handleOffline = () => {
-      addToast({ type: 'warning', message: 'Connexion internet perdue. Le progrès sera sauvegardé localement.' });
+      addToast('Connexion internet perdue. Le progrès sera sauvegardé localement.', 'warning');
     };
 
     window.addEventListener('online', handleOnline);

--- a/src/components/GameControls.tsx
+++ b/src/components/GameControls.tsx
@@ -63,7 +63,7 @@ const GameControls: React.FC<GameControlsProps> = ({ game }) => {
   if (!isMyTurn) {
     return (
       <div className="game-controls">
-        <p>C'est au tour de {game.players.find(p => p.id === game.currentPlayerId)?.name}...</p>
+        <p>C'est au tour de {game.players.find(p => p.uid === game.currentPlayerId)?.displayName}...</p>
       </div>
     );
   }

--- a/src/components/GameLobbyModal.tsx
+++ b/src/components/GameLobbyModal.tsx
@@ -3,13 +3,10 @@ import React, { useState, useEffect } from "react";
 import {
   collection,
   onSnapshot,
-  serverTimestamp,
   query,
   where,
   getDocs,
-  deleteDoc,
-  doc,
-} from "firebase/firestore"; // Removed addDoc
+} from "firebase/firestore"; // Removed addDoc, serverTimestamp, deleteDoc, doc
 import { db, functions } from "../firebaseConfig";
 import { httpsCallable } from "firebase/functions";
 import { useNavigate } from "react-router-dom";

--- a/src/components/HallOfFame.test.tsx
+++ b/src/components/HallOfFame.test.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import HallOfFame from './HallOfFame';
 import type { PlayerStats } from '../hooks/useAuth'; // Utiliser import type
-import { AchievementDefinition, achievementDefinitions } from '../data/achievementDefinitions'; // Importer les vraies définitions
+import { achievementDefinitions } from '../data/achievementDefinitions'; // Importer les vraies définitions, removed AchievementDefinition type import
 
 // Mock le module useAuth pour éviter l'initialisation de Firebase via firebaseConfig
 vi.mock('../hooks/useAuth', () => ({

--- a/src/components/HallOfFame.tsx
+++ b/src/components/HallOfFame.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { PlayerStats } from '../hooks/useAuth'; // Corrigé
-import { achievementDefinitions, getAchievementDefinition } from '../data/achievementDefinitions'; // Corrigé
+import type { PlayerStats } from '../hooks/useAuth'; // Corrigé
+import { getAchievementDefinition } from '../data/achievementDefinitions'; // Corrigé, removed achievementDefinitions
 import './HallOfFame.css';
 
 interface HallOfFameProps {

--- a/src/components/PhaserGame.tsx
+++ b/src/components/PhaserGame.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import Phaser from 'phaser';
 import MainBoardScene from '../phaser/MainBoardScene';
 import type { Game } from '../types/game';
-import { SPELL_DEFINITIONS, SpellType, type SpellId } from '../data/spells'; // Importer le type
+import { SPELL_DEFINITIONS, type SpellType, type SpellId } from '../data/spells'; // Importer le type
 
 interface PhaserGameProps {
   game: Game | null;

--- a/src/components/QuestLog.test.tsx
+++ b/src/components/QuestLog.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import QuestLog from './QuestLog';
-import { Quest } from '../types/game';
+import type { Quest } from '../types/game';
 
 import { vi } from 'vitest';
 
@@ -108,7 +107,7 @@ describe('<QuestLog />', () => {
 
     // Configurer le mock de subscribeToActiveQuests
     (questService.subscribeToActiveQuests as ReturnType<typeof vi.fn>).mockImplementation(
-      (userId: string, onUpdate: (quests: Quest[]) => void, onError: (error: Error) => void) => {
+      (_userId: string, onUpdate: (quests: Quest[]) => void, _onError: (error: Error) => void) => {
         // Appeler immédiatement onUpdate avec les données mockées
         // Le composant mettra à jour son état et setLoadingActiveQuests à false
         onUpdate(mockActiveQuests);
@@ -118,7 +117,7 @@ describe('<QuestLog />', () => {
 
     // Configurer le mock de subscribeToCompletedQuests
     (questService.subscribeToCompletedQuests as ReturnType<typeof vi.fn>).mockImplementation(
-      (userId: string, onUpdate: (quests: Quest[]) => void, onError: (error: Error) => void) => {
+      (_userId: string, onUpdate: (quests: Quest[]) => void, _onError: (error: Error) => void) => {
         onUpdate(mockCompletedQuests);
         return vi.fn(); // Retourner une fonction de désinscription mockée
       }

--- a/src/components/QuestLog.tsx
+++ b/src/components/QuestLog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
-import { Quest } from '../types/game';
+import type { Quest } from '../types/game';
 import { useTranslation } from 'react-i18next';
 import { subscribeToActiveQuests, subscribeToCompletedQuests } from '../services/questService';
 

--- a/src/components/ReviewSession.tsx
+++ b/src/components/ReviewSession.tsx
@@ -38,7 +38,7 @@ const ReviewSession: React.FC<ReviewSessionProps> = ({ reviewItems, onSessionEnd
 
   const handleResponse = async (isCorrect: boolean) => {
     if (!currentItem || !user) {
-      addToast({ type: 'error', message: 'Erreur: Item ou utilisateur non défini.' });
+      addToast('Erreur: Item ou utilisateur non défini.', 'error');
       return;
     }
 
@@ -54,10 +54,10 @@ const ReviewSession: React.FC<ReviewSessionProps> = ({ reviewItems, onSessionEnd
           isCorrect,
           userId: user.uid, // Pass userId
         });
-        addToast({ type: 'info', message: `Progrès sauvegardé localement pour ${currentItem.word || currentItem.spellId}.` });
+        addToast(`Progrès sauvegardé localement pour ${currentItem.word || currentItem.spellId}.`, 'info');
       } catch (error) {
         console.error("Erreur lors de l'ajout à la file de synchronisation:", error);
-        addToast({ type: 'error', message: "Échec de la sauvegarde locale du progrès." });
+        addToast("Échec de la sauvegarde locale du progrès.", 'error');
       }
     } else {
       console.log(`Mode en ligne: Mise à jour de ${currentItem.spellId} sur le serveur.`);
@@ -67,10 +67,10 @@ const ReviewSession: React.FC<ReviewSessionProps> = ({ reviewItems, onSessionEnd
           isCorrect
         });
         console.log(`Review item ${currentItem.spellId} updated on server.`);
-        addToast({ type: 'success', message: `Progrès synchronisé pour ${currentItem.word || currentItem.spellId}.` });
+        addToast(`Progrès synchronisé pour ${currentItem.word || currentItem.spellId}.`, 'success');
       } catch (error) {
         console.error("Erreur lors de la mise à jour de l'item (en ligne):", error);
-        addToast({ type: 'warning', message: `Échec de la synchronisation pour ${currentItem.word || currentItem.spellId}. Sauvegardé localement.` });
+        addToast(`Échec de la synchronisation pour ${currentItem.word || currentItem.spellId}. Sauvegardé localement.`, 'warning');
         // Fallback: add to sync queue if online update fails
         try {
           await addToSyncQueue({
@@ -80,7 +80,7 @@ const ReviewSession: React.FC<ReviewSessionProps> = ({ reviewItems, onSessionEnd
           });
         } catch (syncError) {
           console.error("Erreur lors de l'ajout à la file de synchronisation (fallback):", syncError);
-          addToast({ type: 'error', message: "Échec critique: Impossible de sauvegarder le progrès." });
+          addToast("Échec critique: Impossible de sauvegarder le progrès.", 'error');
         }
       }
     }

--- a/src/components/ShopModal.tsx
+++ b/src/components/ShopModal.tsx
@@ -35,7 +35,7 @@ type TabCategory = 'tenues' | 'familiers' | 'effets' | 'themes';
 
 const ShopModal: React.FC<ShopModalProps> = ({ isOpen, onClose }) => {
   const [activeTab, setActiveTab] = useState<TabCategory>('tenues');
-  const [moonShards, setMoonShards] = useState(5000); // Solde fictif
+  const [moonShards] = useState(5000); // Solde fictif, removed setMoonShards
 
   if (!isOpen) {
     return null;

--- a/src/components/Spellbook.test.tsx
+++ b/src/components/Spellbook.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
@@ -24,40 +23,41 @@ vi.mock('react-i18next', () => ({
 
 // Mock player data for testing
 const mockPlayer: Player = {
-  id: 'player-1',
-  uid: 'player-1', // Added uid to match Player type
-  name: 'Test Player',
-  displayName: 'Test Player', // Added displayName
-  hp: 100,
+  uid: 'player-1',
+  displayName: 'Test Player',
+  // hp: 100, // hp, name, etc. are not in the Player type from src/types/game.ts
   mana: 100,
   position: 0,
   effects: [],
-  spells: SPELL_DEFINITIONS.map(spell => spell.id), // Populate with all spell IDs for Spellbook to render them
+  // spells: SPELL_DEFINITIONS.map(spell => spell.id), // spells is not in Player type
   grimoires: [],
-  influence: 0,
-  gold: 0,
-  inventory: [],
-  quests: [],
-  isProtected: false,
-  skipNextTurn: false,
-  extraRolls: 0,
-  rollModifier: 0,
-  luck: 0,
-  lastDiceRoll: null,
-  eventDeck: [],
-  playedEventCardIds: [],
-  guildId: null,
-  avatarUrl: '',
-  title: '',
-  joinDate: new Date().toISOString(),
-  lastLoginDate: new Date().toISOString(),
-  stats: {
-    gamesPlayed:0,
-    gamesWon:0,
-    damageDealt:0,
-    manaSpent:0,
-    spellsCast:0,
-  }
+  // influence: 0, // Not in Player type
+  // gold: 0, // Not in Player type
+  // inventory: [], // Not in Player type
+  // quests: [], // Not in Player type
+  // isProtected: false, // Not in Player type
+  // skipNextTurn: false, // Not in Player type
+  // extraRolls: 0, // Not in Player type
+  // rollModifier: 0, // Not in Player type
+  // luck: 0, // Not in Player type
+  // lastDiceRoll: null, // Not in Player type
+  // eventDeck: [], // Not in Player type
+  // playedEventCardIds: [], // Not in Player type
+  guildId: undefined,
+  // avatarUrl: '', // Not in Player type
+  // title: '', // Not in Player type
+  // joinDate: new Date().toISOString(), // Not in Player type
+  // lastLoginDate: new Date().toISOString(), // Not in Player type
+  // stats: { // Not in Player type
+  //   gamesPlayed:0,
+  //   gamesWon:0,
+  //   damageDealt:0,
+  //   manaSpent:0,
+  //   spellsCast:0,
+  // }
+  // Minimal Player type from src/types/game.ts
+  groundHeight: 0, // Added missing required property
+  blocks: [], // Added missing required property
 };
 
 describe('Spellbook', () => {

--- a/src/components/Spellbook.tsx
+++ b/src/components/Spellbook.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SPELL_DEFINITIONS, type SpellId, SpellType } from '../data/spells'; // Added SpellType
+import { SPELL_DEFINITIONS, type SpellId, type SpellType } from '../data/spells'; // Changed SpellType to type import
 import type { Player } from '../types/game';
 import './Spellbook.css';
 
@@ -54,7 +54,7 @@ const Spellbook: React.FC<SpellbookProps> = (props) => {
             // If selected and targeting mode is active for this spell, show "Targeting..."
             // Otherwise, show "Cancel"
             const spellDefinition = SPELL_DEFINITIONS.find(s => s.id === spell.id);
-            if (spellDefinition && spellDefinition.type !== SpellType.SELF && isTargetingMode) {
+            if (spellDefinition && spellDefinition.type !== "SELF" && isTargetingMode) {
               buttonTextKey = 'spellbook.targeting_button'; // New key: "Ciblage..."
             } else {
               buttonTextKey = 'spellbook.cancel_button';

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -49,3 +49,12 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
     </ToastContext.Provider>
   );
 };
+
+// Custom hook to use the ToastContext
+export const useToasts = (): ToastContextType => {
+  const context = React.useContext(ToastContext);
+  if (context === undefined) {
+    throw new Error('useToasts must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/src/data/achievementDefinitions.ts
+++ b/src/data/achievementDefinitions.ts
@@ -1,4 +1,4 @@
-import { PlayerStats } from '../hooks/useAuth'; // Importer PlayerStats pour keyof
+import type { PlayerStats } from '../hooks/useAuth'; // Importer PlayerStats pour keyof
 
 export interface AchievementDefinition {
   id: string;

--- a/src/data/spells.ts
+++ b/src/data/spells.ts
@@ -10,12 +10,10 @@ export type SpellId =
   "KARMIC_SWAP" |       // Échange Karmique
   "DOKKAEBI_MISCHIEF";  // Malice du Dokkaebi
 
-export enum SpellType {
-  TARGET_TILE = "TARGET_TILE",
-  SELF = "SELF",
-  TARGET_PLAYER = "TARGET_PLAYER",
-  // Add other types as needed, e.g., TARGET_ENEMY, AOE_TILE, etc.
-}
+// Changed SpellType to a string literal union
+export type SpellType = "TARGET_TILE" | "SELF" | "TARGET_PLAYER";
+// Add other types as needed, e.g., TARGET_ENEMY, AOE_TILE, etc.
+
 
 // The 'type' field from the mission brief (DEFENSIVE, CHAOS, TRAP) describes the spell's *effect category*
 // while SpellType here describes the *targeting mechanism* for the frontend.
@@ -37,7 +35,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.push_back.description",
     manaCost: 15,
     requiresTarget: true,
-    type: SpellType.TARGET_PLAYER,
+    type: "TARGET_PLAYER",
     effectCategory: "OFFENSIVE",
   },
   {
@@ -46,7 +44,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.mana_drain.description",
     manaCost: 5,
     requiresTarget: true,
-    type: SpellType.TARGET_PLAYER,
+    type: "TARGET_PLAYER",
     effectCategory: "OFFENSIVE",
   },
   {
@@ -55,7 +53,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.trap_rune.description",
     manaCost: 30, // Example, might be different from Dokkaebi's Mischief
     requiresTarget: true,
-    type: SpellType.TARGET_TILE,
+    type: "TARGET_TILE",
     effectCategory: "TRAP",
   },
   {
@@ -64,7 +62,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.mana_shield.description",
     manaCost: 25, // Example, might be different from Memory Fog
     requiresTarget: false,
-    type: SpellType.SELF,
+    type: "SELF",
     effectCategory: "DEFENSIVE",
   },
   {
@@ -73,7 +71,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.astral_swap.description",
     manaCost: 40, // Example, might be different from Karmic Swap
     requiresTarget: true,
-    type: SpellType.TARGET_PLAYER,
+    type: "TARGET_PLAYER",
     effectCategory: "UTILITY", // Or CHAOS, depending on interpretation
   },
   // New Spells from "L'Art de l'Enchantement"
@@ -83,7 +81,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.memory_fog.description", // Key for "Vous protège du prochain sort négatif lancé contre vous."
     manaCost: 25,
     requiresTarget: false, // Targets self
-    type: SpellType.SELF,
+    type: "SELF",
     effectCategory: "DEFENSIVE",
   },
   {
@@ -92,7 +90,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.karmic_swap.description", // Key for "Échangez votre position sur le plateau avec un autre joueur."
     manaCost: 40,
     requiresTarget: true, // Needs a target player
-    type: SpellType.TARGET_PLAYER,
+    type: "TARGET_PLAYER",
     effectCategory: "CHAOS",
   },
   {
@@ -101,7 +99,7 @@ export const SPELL_DEFINITIONS: Spell[] = [
     descriptionKey: "spells.dokkaebi_mischief.description", // Key for "Placez un piège invisible sur une case. Le prochain joueur à s'y arrêter perd 15 Mana."
     manaCost: 30,
     requiresTarget: true, // Needs a target tile
-    type: SpellType.TARGET_TILE,
+    type: "TARGET_TILE",
     effectCategory: "TRAP",
   },
 ];

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -17,7 +17,7 @@ export interface PlayerStats {
 // Placeholder for user profile data structure
 // In a real app, this would likely come from Firestore (e.g., a 'users' collection
 // where each document has a 'guildId' field) or from Firebase Auth custom claims.
-interface UserProfile extends User {
+export interface UserProfile extends User { // Added export
   guildId?: string | null; // Stores the ID of the guild the user belongs to, if any.
   stats?: PlayerStats; // Player statistics
   unlockedAchievements?: string[]; // Array of achievement IDs

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '../hooks/useAuth';
 import { db } from '../firebaseConfig';
 import { castSpell } from '../services/gameService'; // Importer castSpell
 import soundService from '../services/soundService'; // Import soundService
-import { SPELL_DEFINITIONS, SpellType, type SpellId } from '../data/spells'; // Importer le type SpellId
+import { SPELL_DEFINITIONS, type SpellType, type SpellId } from '../data/spells'; // Importer le type SpellId, SpellType as type
 import PhaserGame from '../components/PhaserGame';
 import PlayerHUD from '../components/PlayerHUD';
 import GameControls from '../components/GameControls';
@@ -61,7 +61,7 @@ const GamePage: React.FC = () => {
         setGame({ id: doc.id, ...doc.data() } as Game);
 
         if (user) {
-          const playerData = gameData.players.find(p => p.id === user.uid);
+          const playerData = gameData.players.find(p => p.uid === user.uid);
           setCurrentPlayer(playerData || null);
         }
       } else {
@@ -143,7 +143,7 @@ const GamePage: React.FC = () => {
     }
 
     // Handle self-cast spells immediately
-    if (spellDefinition.type === SpellType.SELF) {
+    if (spellDefinition.type === "SELF") {
       if (game && user && !isCastingSpell) {
         console.log(`[React] Casting self-spell ${spellId} for game ${game.id}`);
         soundService.playSound('action_spell_cast_generic'); // Sound for casting
@@ -178,7 +178,7 @@ const GamePage: React.FC = () => {
     if (game && selectedSpellId && selectedTargetId && user) {
       const spellDefinition = SPELL_DEFINITIONS.find(s => s.id === selectedSpellId);
       // Ensure it's not a SELF spell trying to cast via target selection.
-      if (spellDefinition && spellDefinition.type !== SpellType.SELF && !isCastingSpell) {
+      if (spellDefinition && spellDefinition.type !== "SELF" && !isCastingSpell) {
         console.log(`[React] Casting targeted spell ${selectedSpellId} on ${selectedTargetId} for game ${game.id}`);
         soundService.playSound('action_spell_cast_generic'); // Sound for casting
         setIsCastingSpell(true);
@@ -204,15 +204,15 @@ const GamePage: React.FC = () => {
 
   // AJOUT : Vérifier si la partie est terminée
   if (game.status === 'finished') {
-    const winner = game.players.find(p => p.id === game.winnerId);
-    const winnerName = winner ? winner.name : 'Un sorcier mystérieux';
+    const winner = game.players.find(p => p.uid === game.winnerId);
+    const winnerName = winner ? winner.displayName : 'Un sorcier mystérieux';
     
     return <VictoryScreen winnerName={winnerName} />;
   }
 
   const isMyTurn = user ? game.currentPlayerId === user.uid : false;
-  const activePlayer = game.players.find(p => p.id === game.currentPlayerId);
-  const activePlayerName = activePlayer ? activePlayer.name : 'Adversaire inconnu';
+  const activePlayer = game.players.find(p => p.uid === game.currentPlayerId);
+  const activePlayerName = activePlayer ? activePlayer.displayName : 'Adversaire inconnu';
 
 
   // Le rendu normal du jeu si la partie n'est pas terminée
@@ -240,7 +240,7 @@ const GamePage: React.FC = () => {
                     onSelectSpell={handleSelectSpell}
                     isCastingSpell={isCastingSpell}
                     castingSpellId={selectedSpellId} // Pass selectedSpellId as castingSpellId
-                    isTargetingMode={selectedSpellId !== null && SPELL_DEFINITIONS.find(s => s.id === selectedSpellId)?.type !== SpellType.SELF}
+                    isTargetingMode={selectedSpellId !== null && SPELL_DEFINITIONS.find(s => s.id === selectedSpellId)?.type !== "SELF"}
                   />
                   <GameControls game={game} />
                 </>

--- a/src/pages/HubPage.tsx
+++ b/src/pages/HubPage.tsx
@@ -20,7 +20,7 @@ const HubPage: React.FC = () => {
   const [isQuestLogModalOpen, setIsQuestLogModalOpen] = useState(false); // État pour le modal de quêtes
   const [isDailyChallengeModalOpen, setIsDailyChallengeModalOpen] = useState(false);
   const [isShopModalOpen, setIsShopModalOpen] = useState(false); // État pour la modale de la boutique
-  const [currentChallenge, setCurrentChallenge] = useState({
+  const [currentChallenge, _setCurrentChallenge] = useState({
     title: "Défi de l'Interprète",
     objective: "Atteignez un combo de 15 dans le Défi de l'Interprète",
     reward: "50 Mana + 1 Potion de Clarté",
@@ -46,7 +46,7 @@ const HubPage: React.FC = () => {
         physics: {
           default: 'arcade',
           arcade: {
-            gravity: { y: 0 },
+            gravity: { x: 0, y: 0 },
             debug: false // Set to true for debugging physics
           }
         }
@@ -125,6 +125,12 @@ const HubPage: React.FC = () => {
       <GameLobbyModal
         isOpen={isGameLobbyModalOpen}
         onClose={() => setIsGameLobbyModalOpen(false)}
+        onDelete={(gameId) => {
+          // Placeholder for game deletion logic
+          // This might involve calling a service, then updating UI if necessary
+          console.log(`HubPage: Request to delete game ${gameId}`);
+          // Example: remove game from a local list if games were fetched and stored in HubPage's state
+        }}
       />
       <GuildManagementModal
         isOpen={isGuildModalOpen}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,11 +9,12 @@ import { useTranslation } from 'react-i18next';
 
 const LoginPage: React.FC = () => {
   const { t } = useTranslation();
+  // const { t } = useTranslation(); // Removed duplicate declaration
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [loading, setLoading] = useState(false);
+  const [_loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
    const handleSignInOrCreate = async (e: React.FormEvent) => {

--- a/src/pages/ProfilePage.test.tsx
+++ b/src/pages/ProfilePage.test.tsx
@@ -3,11 +3,11 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import ProfilePage from './ProfilePage';
 import { useAuth } from '../hooks/useAuth'; // Importer le hook uniquement
-import type { ToastContextType } from '../contexts/ToastContext'; // Importer uniquement le type
+// import type { ToastContextType } from '../contexts/ToastContext'; // Removed unused type import
 import { useToasts } from '../contexts/useToasts';
 import { getAchievementDefinition } from '../data/achievementDefinitions';
 
-import type { UserProfile } from '../hooks/useAuth'; // Import UserProfile for typing mocks
+// import type { UserProfile } from '../hooks/useAuth'; // Removed unused type import
 
 // Mock partiel de useAuth
 vi.mock('../hooks/useAuth', async (importOriginal) => {
@@ -18,12 +18,7 @@ vi.mock('../hooks/useAuth', async (importOriginal) => {
   };
 });
 
-// Define a type for the mock implementation of useAuth based on its actual return type
-type MockUseAuth = {
-  user: UserProfile | null;
-  loading: boolean;
-  updateUserGuildId: ReturnType<typeof vi.fn>;
-};
+// Unused MockUseAuth type removed
 
 // Mock for useToasts hook
 vi.mock('../contexts/useToasts', () => ({
@@ -69,17 +64,13 @@ vi.mock('firebase/firestore', () => ({
     }
     return vi.fn(); // unsubscribe
   }),
-  collection: vi.fn((db, path) => ({ // Ajouter mock pour collection
-    path: path, // pour aider au debug si besoin
-    // Si GrimoireVivant utilise query().onSnapshot(), il faudra l'ajouter ici.
-    // Pour l'instant, on suppose que le onSnapshot mocké ci-dessus est suffisant
-    // ou que GrimoireVivant a une logique de fallback simple.
-    // Pour être plus robuste, on pourrait retourner un objet avec une méthode query,
-    // qui retourne un objet avec une méthode onSnapshot.
-    // Pour l'instant, on le garde simple.
+  // Corrected: Only one definition of collection, with the _db fix
+  collection: vi.fn((_db, path) => ({
+    path: path,
   })),
-  query: vi.fn(ref => ref), // Si query est appelé, il retourne la référence
+  query: vi.fn(ref => ref),
 }));
+
 vi.mock('firebase/functions', () => ({
   getFunctions: vi.fn(),
   httpsCallable: vi.fn(),

--- a/src/phaser/game.ts
+++ b/src/phaser/game.ts
@@ -12,7 +12,7 @@ const config: Phaser.Types.Core.GameConfig = {
   physics: {
     default: 'arcade',
     arcade: {
-      gravity: { y: 0 },
+      gravity: { x: 0, y: 0 },
       debug: false
     }
   },

--- a/src/services/questService.ts
+++ b/src/services/questService.ts
@@ -1,6 +1,6 @@
-import { collection, query, onSnapshot, DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
+import { collection, query, onSnapshot, type DocumentData, type QueryDocumentSnapshot } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
-import { Quest } from '../types/game';
+import type { Quest } from '../types/game';
 
 type QuestSubscriptionCallback = (quests: Quest[]) => void;
 type ErrorCallback = (error: Error) => void;

--- a/src/services/soundService.ts
+++ b/src/services/soundService.ts
@@ -46,11 +46,11 @@ class SoundService {
           this.sounds.set(definition.name, sound);
           resolve();
         },
-        onloaderror: (id, error) => {
+        onloaderror: (_id, error) => {
           console.error(`SoundService: Error loading sound ${definition.name} from ${definition.path}:`, error);
           reject(error);
         },
-        onplayerror: (id, error) => {
+        onplayerror: (_id, error) => {
           console.error(`SoundService: Error playing sound ${definition.name}:`, error);
           // Potentially try to unlock audio context if it's an interaction issue
           if (Howler.ctx && Howler.ctx.state === 'suspended') {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -62,9 +62,11 @@ export interface Game {
 
 export interface SpellMasteryData {
   spellId: SpellId;
+  word?: string; // The actual word/phrase if it's a word rune, or could be spell name
   masteryLevel: number; // e.g., 0 for unlearned, 1 for basic, 2 for mastered
   successfulCasts: number; // Number of times the spell has been cast successfully
   failedCasts: number; // Number of times the spell failed (e.g., due to lack of mana, target out of range)
+  nextReviewDate?: number; // Unix timestamp (milliseconds) for next scheduled review
   // Optional: could add lastUsedTimestamp, specific spell stats, etc.
 }
 


### PR DESCRIPTION
- Corrected Player type usage (uid, displayName).
- Ensured useToasts hook is exported and used correctly.
- Updated SpellMasteryData interface and fixed related errors.
- Addressed type-only import errors (TS1484) with `import type`.
- Resolved many unused variable errors (TS6133) by removing or prefixing.
- Fixed Phaser-specific errors (gravity, null checks, object properties, types).
- Corrected miscellaneous errors including enum syntax, mock data, and duplicate properties in tests.

Note: Some TS6133 errors for type-only imports and Phaser scene objects remain, likely due to strict build config rather than functional issues.