### PR TITLE
Fix: Resolve build errors and TypeScript issues

### DIFF
--- a/src/components/PhaserGame.tsx
+++ b/src/components/PhaserGame.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import Phaser from 'phaser';
 import MainBoardScene from '../phaser/MainBoardScene';
 import type { Game } from '../types/game';
-import { SPELL_DEFINITIONS, type SpellType, type SpellId } from '../data/spells'; // Importer le type
+import { SPELL_DEFINITIONS, type SpellId } from '../data/spells'; // Importer le type, SpellType removed
 
 interface PhaserGameProps {
   game: Game | null;

--- a/src/components/Spellbook.test.tsx
+++ b/src/components/Spellbook.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import Spellbook from './Spellbook';
-import { SPELL_DEFINITIONS, type SpellId } from '../data/spells'; // For test data
+import { SPELL_DEFINITIONS } from '../data/spells'; // For test data, SpellId removed
 import type { Player } from '../types/game';
 
 // Mock react-i18next

--- a/src/components/Spellbook.tsx
+++ b/src/components/Spellbook.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SPELL_DEFINITIONS, type SpellId, type SpellType } from '../data/spells'; // Changed SpellType to type import
+import { SPELL_DEFINITIONS, type SpellId } from '../data/spells'; // SpellType removed
 import type { Player } from '../types/game';
 import './Spellbook.css';
 

--- a/src/pages/GamePage.test.tsx
+++ b/src/pages/GamePage.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, within, act } from '@testing-library/react'; // Added w
 import userEvent from '@testing-library/user-event'; // Added userEvent
 import GamePage from './GamePage';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-// SPELL_DEFINITIONS is needed for test bodies. SpellType is also needed.
-import { SPELL_DEFINITIONS, type SpellType } from '../data/spells'; // Changed SpellType to type import
+// SPELL_DEFINITIONS is needed for test bodies.
+import { SPELL_DEFINITIONS } from '../data/spells'; // SpellType removed
 import { castSpell } from '../services/gameService'; // Import the mock to allow vi.mocked(castSpell)
 
 // Mock soundService

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '../hooks/useAuth';
 import { db } from '../firebaseConfig';
 import { castSpell } from '../services/gameService'; // Importer castSpell
 import soundService from '../services/soundService'; // Import soundService
-import { SPELL_DEFINITIONS, type SpellType, type SpellId } from '../data/spells'; // Importer le type SpellId, SpellType as type
+import { SPELL_DEFINITIONS, type SpellId } from '../data/spells'; // Importer le type SpellId, SpellType removed
 import PhaserGame from '../components/PhaserGame';
 import PlayerHUD from '../components/PlayerHUD';
 import GameControls from '../components/GameControls';

--- a/src/phaser/HangeulTyphoonScene.ts
+++ b/src/phaser/HangeulTyphoonScene.ts
@@ -22,7 +22,7 @@ export default class HangeulTyphoonScene extends Phaser.Scene {
   private targetedBlock: Phaser.GameObjects.Text | null = null;
 
   private isGameOver: boolean = false;
-  private gameOverText!: Phaser.GameObjects.Text;
+  // private _gameOverText!: Phaser.GameObjects.Text; // Removed
   private groundY!: number;
   private blockSpawnTimer!: Phaser.Time.TimerEvent;
 
@@ -54,7 +54,7 @@ export default class HangeulTyphoonScene extends Phaser.Scene {
   private readonly COMBO_TIMEOUT: number = 3000; // 3 seconds
 
   private currentGameMode: string = 'eupreuveDuScribe'; // Default mode
-  private modeText!: Phaser.GameObjects.Text; // Reference to HUD mode text
+  // private _modeText!: Phaser.GameObjects.Text; // Removed, Reference to HUD mode text
   private translationPairs: { lang1: string, lang2_korean: string, type: 'word' | 'phrase' }[] = [
     { lang1: "Maison", lang2_korean: "집", type: 'word' },
     { lang1: "Amour", lang2_korean: "사랑", type: 'word' },
@@ -150,7 +150,7 @@ export default class HangeulTyphoonScene extends Phaser.Scene {
       // Add display name for Test du Traducteur if different, otherwise it uses Scribe
       modeDisplayName = 'Test du Traducteur'; // Placeholder, adjust if needed
     }
-    this.modeText = this.add.text(gameWidth * 0.9, hudY, `Mode: ${modeDisplayName}`, hudStyle).setOrigin(1, 0);
+     this.add.text(gameWidth * 0.9, hudY, `Mode: ${modeDisplayName}`, hudStyle).setOrigin(1, 0); // Assignment to _modeText removed
 
     // Define game area dimensions and position
     // HUD will be above, input field below.
@@ -624,7 +624,7 @@ export default class HangeulTyphoonScene extends Phaser.Scene {
     }
     // // this.sound.play('sfx_game_over_typhoon'); // Or specific win/loss sounds
 
-    this.gameOverText = this.add.text(
+     this.add.text( // Assignment to _gameOverText removed
       gameWidth / 2, gameHeight / 2, outcomeMessage,
       { fontSize: '64px', color: outcomeStatus === 'defeat' ? '#ff0000' : '#00ff00', backgroundColor: '#000000' }
     ).setOrigin(0.5);
@@ -674,7 +674,7 @@ export default class HangeulTyphoonScene extends Phaser.Scene {
     console.log(`Duel ended by server. Winner: ${winnerId || 'None'}. Player is: ${this.attackerPlayerId}. Outcome: ${outcomeStatus}`);
     // // Play win/loss/draw sound
 
-    this.gameOverText = this.add.text(
+     this.add.text( // Assignment to _gameOverText removed
       gameWidth / 2, gameHeight / 2, outcomeMessage,
       { fontSize: '64px', color: outcomeStatus === 'victory' ? '#00ff00' : (outcomeStatus === 'defeat' ? '#ff0000' : '#ffff00'), backgroundColor: '#000000' }
     ).setOrigin(0.5);


### PR DESCRIPTION
- Resolved TS2304 error for 'handleOnline' in App.tsx by moving it to component scope and using useCallback.
- Fixed TS2448 error by reordering function definitions in App.tsx (`processSyncQueue` before `handleOnline`).
- Corrected useCallback dependencies for `processSyncQueue`.
- Cleaned up duplicated code in App.tsx that occurred during refactoring.
- Addressed multiple TS6133 errors (unused variables/imports) across several files:
    - Removed unused `SpellType` and `SpellId` imports.
    - Removed unused class property assignments for Phaser text objects in HangeulTyphoonScene.ts (`gameOverText`, `modeText`) by directly adding them to the scene.

Build is now successful.