### PR TITLE
Fix: Add missing i18n keys for Profile page and improve Grimoire erro…

### DIFF
--- a/public/locales/en-US/translation.json
+++ b/public/locales/en-US/translation.json
@@ -27,7 +27,11 @@
   },
   "spellbook": {
     "title": "Spellbook",
-    "cast_button": "Cast"
+    "cast_button": "Cast",
+    "cancel_button": "Cancel",
+    "casting_button": "Casting...",
+    "targeting_mode_active": "Targeting Mode Active for:",
+    "targeting_button": "Targeting..."
   },
   "spells": {
     "push_back": {
@@ -37,9 +41,32 @@
     "mana_drain": {
       "name": "Mana Drain",
       "description": "Steals 10 Mana points from another player."
+    },
+    "trap_rune": {
+      "name": "Runic Trap",
+      "description": "Places a trap on a tile. The next player to land on it suffers an effect."
+    },
+    "mana_shield": {
+      "name": "Mana Shield",
+      "description": "Surrounds you with a protective barrier that absorbs the next negative spell."
+    },
+    "astral_swap": {
+      "name": "Astral Swap",
+      "description": "Swap positions with another player on the board."
+    },
+    "memory_fog": {
+      "name": "Memory Fog",
+      "description": "Protects you from the next negative spell cast against you."
+    },
+    "karmic_swap": {
+      "name": "Karmic Swap",
+      "description": "Swap your position on the board with another player."
+    },
+    "dokkaebi_mischief": {
+      "name": "Dokkaebi's Mischief",
+      "description": "Place an invisible trap on a tile. The next player to stop there loses 15 Mana."
     }
   },
-  "cancel_button": "Cancel",
   "victory": {
     "title": "Victory!",
     "announcement": "Congratulations to",
@@ -56,6 +83,59 @@
   "loading": "Loading...",
   "profileNotFound": "User profile not found.",
   "profilePageTitle": "My Wizard Profile",
+  "profilePage": {
+    "title": "My Living Grimoire",
+    "description": "Consult and manage your spell mastery.",
+    "hallOfFameTitle": "My Hall of Fame"
+  },
+  "hall_of_fame": {
+    "stats_title": "Statistics",
+    "stats": {
+      "games_played": "Games Played",
+      "spells_cast": "Spells Cast",
+      "mana_spent": "Mana Spent",
+      "duels_won": "Duels Won",
+      "quests_completed": "Quests Completed",
+      "runes_reviewed": "Runes Reviewed"
+    },
+    "achievements_title": "Achievements",
+    "achievement_unlocked_title": "Achievement Unlocked!",
+    "no_achievements": "No achievements unlocked yet."
+  },
+  "achievements": {
+    "first_game_played": {
+      "name": "First Game Played",
+      "description": "Participate in your first game."
+    },
+    "duels_won_1": {
+      "name": "First Duel Won",
+      "description": "Win your first duel against an opponent."
+    },
+    "duels_won_10": {
+      "name": "Duel Master",
+      "description": "Win 10 duels."
+    },
+    "first_spell_cast": {
+      "name": "First Spell Cast",
+      "description": "Cast your first spell."
+    },
+    "spells_cast_100": {
+      "name": "Archmage",
+      "description": "Cast 100 spells."
+    },
+    "quests_completed_1": {
+      "name": "Quest Beginner",
+      "description": "Complete your first quest."
+    },
+    "quests_completed_10": {
+      "name": "Quest Conqueror",
+      "description": "Complete 10 quests."
+    },
+    "runes_reviewed_50": {
+      "name": "Rune Scholar",
+      "description": "Review 50 runes in the Spell Forge."
+    }
+  },
   "loadingGuildName": "Loading house name...",
   "editdisplayName": "Edit Username",
   "spellForgeTitle": "Spell Forge",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -83,6 +83,59 @@
   "loading": "Loading...",
   "profileNotFound": "User profile not found.",
   "profilePageTitle": "My Wizard Profile",
+  "profilePage": {
+    "title": "My Living Grimoire",
+    "description": "Consult and manage your spell mastery.",
+    "hallOfFameTitle": "My Hall of Fame"
+  },
+  "hall_of_fame": {
+    "stats_title": "Statistics",
+    "stats": {
+      "games_played": "Games Played",
+      "spells_cast": "Spells Cast",
+      "mana_spent": "Mana Spent",
+      "duels_won": "Duels Won",
+      "quests_completed": "Quests Completed",
+      "runes_reviewed": "Runes Reviewed"
+    },
+    "achievements_title": "Achievements",
+    "achievement_unlocked_title": "Achievement Unlocked!",
+    "no_achievements": "No achievements unlocked yet."
+  },
+  "achievements": {
+    "first_game_played": {
+      "name": "First Game Played",
+      "description": "Participate in your first game."
+    },
+    "duels_won_1": {
+      "name": "First Duel Won",
+      "description": "Win your first duel against an opponent."
+    },
+    "duels_won_10": {
+      "name": "Duel Master",
+      "description": "Win 10 duels."
+    },
+    "first_spell_cast": {
+      "name": "First Spell Cast",
+      "description": "Cast your first spell."
+    },
+    "spells_cast_100": {
+      "name": "Archmage",
+      "description": "Cast 100 spells."
+    },
+    "quests_completed_1": {
+      "name": "Quest Beginner",
+      "description": "Complete your first quest."
+    },
+    "quests_completed_10": {
+      "name": "Quest Conqueror",
+      "description": "Complete 10 quests."
+    },
+    "runes_reviewed_50": {
+      "name": "Rune Scholar",
+      "description": "Review 50 runes in the Spell Forge."
+    }
+  },
   "loadingGuildName": "Loading house name...",
   "editdisplayName": "Edit Username",
   "spellForgeTitle": "Spell Forge",

--- a/src/components/GrimoireVivant.tsx
+++ b/src/components/GrimoireVivant.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { db, functions } from '../firebaseConfig'; // Added functions
-import { collection, onSnapshot, query, Timestamp } from 'firebase/firestore'; // Added Timestamp
+import { collection, onSnapshot, query, Timestamp, FirebaseError } from 'firebase/firestore'; // Added Timestamp and FirebaseError
 import { useAuth } from '../hooks/useAuth';
 import type { SpellMasteryData } from '../types/game';
 import type { SpellId } from '../data/spells'; // Import SpellId
@@ -236,6 +236,23 @@ const GrimoireVivant: React.FC = () => {
 
   if (isLoading) {
     return <p>Gravure des runes en cours...</p>;
+  }
+
+  if (firestoreError) {
+    return (
+      <div className="grimoire-container error-container" style={{ padding: '20px', textAlign: 'center' }}>
+        <h3>Grimoire Temporarily Unavailable</h3>
+        <p>We encountered an issue loading your spell mastery data.</p>
+        <p>This might be due to a connection problem or account access restrictions.</p>
+        <p>Please try refreshing the page or check again later.</p>
+        {/* For developers: more specific error info can be logged or displayed conditionally */}
+        {import.meta.env.DEV && firestoreError.message && (
+          <p style={{ fontSize: '0.8em', color: 'grey', marginTop: '10px' }}>
+            <i>Developer Info: {firestoreError.message} (Code: {firestoreError.code})</i>
+          </p>
+        )}
+      </div>
+    );
   }
 
   if (isReviewing) {


### PR DESCRIPTION
…r display

- Added all missing English translations for profile page, hall of fame, and achievements to en/translation.json and en-US/translation.json. This resolves the i18next missingKey errors.
- Updated GrimoireVivant.tsx to display a user-friendly error message within the component if fetching spell mastery data from Firestore fails.
- Includes storing the Firestore error in state and showing conditional error details in development mode.