### PR TITLE
Refactor: Improve online event handling for sync queue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,15 +114,24 @@ function App() {
 
   const handleOnline = useCallback(() => {
     addToast('Connexion internet rétablie.', 'info');
-    if (user && !user.isAnonymous) { // Ensure user is logged in
+    // Only proceed if a user is logged in and not anonymous, AND not currently syncing.
+    if (user && !user.isAnonymous && !isSyncing) {
       if (onlineSyncDebounceTimer.current) {
         clearTimeout(onlineSyncDebounceTimer.current);
       }
       onlineSyncDebounceTimer.current = setTimeout(() => {
-        processSyncQueue(user); // processSyncQueue is now defined before this
+        // Double check isSyncing again inside setTimeout, as its state might have changed
+        // during the debounce period by other means (e.g. login sync).
+        if (!isSyncing) {
+          processSyncQueue(user);
+        } else {
+          console.log("Sync: Debounced online sync skipped, another sync is already in progress.");
+        }
       }, 5000); // Debounce for 5 seconds
+    } else if (isSyncing) {
+      console.log("Sync: Online event received, but a sync is already in progress. Ignoring.");
     }
-  }, [user, processSyncQueue, addToast]); // processSyncQueue needs to be in the dependency array if it's used inside
+  }, [user, processSyncQueue, addToast, isSyncing]); // Added isSyncing to dependencies
 
   const handleOffline = useCallback(() => {
     addToast('Connexion internet perdue. Le progrès sera sauvegardé localement.', 'warning');


### PR DESCRIPTION
Refined the `handleOnline` function in `App.tsx` to prevent excessive triggering of the `processSyncQueue`.

- Added a check for the `isSyncing` state within `handleOnline` to avoid queueing a new sync if one is already in progress.
- Updated React hook dependencies accordingly.

This change addresses an issue where `processSyncQueue` could be triggered repeatedly under certain network conditions (e.g., flaky connection, or multiple online events), leading to continuous console logs like "Sync: Queue is empty.". The core offline sync functionality for review sessions remains, but its trigger is now more robust.