### PR TITLE
Fix: Improve Grimoire dev errors and document emulator usage

### DIFF
--- a/docs/05_Guide_Developpeur.md
+++ b/docs/05_Guide_Developpeur.md
@@ -5,13 +5,27 @@
 1.  **Frontend (`korean-party-client`) :**
     -   Assurez-vous d'avoir Node.js et npm installés.
     -   Exécutez `npm install` à la racine du dossier.
-    -   Créez un fichier `.env.local` en vous basant sur `.env.example` et remplissez vos clés de configuration Firebase.
+    -   Créez un fichier `.env` (ou `.env.local` qui est prioritaire et non versionné) à la racine du projet en vous basant sur les variables d'environnement attendues par Firebase (ex: `VITE_FIREBASE_API_KEY`, etc.). Ces variables sont généralement fournies lors de la configuration de votre projet Firebase.
     -   Exécutez `npm run dev` pour lancer le serveur de développement.
-2.  **Backend (`korean-party-functions`) :**
+
+2.  **Backend (Firebase Emulators) :**
     -   Assurez-vous d'avoir Firebase CLI installé (`npm install -g firebase-tools`).
-    -   Naviguez vers le dossier `functions`.
-    -   Exécutez `npm install`.
-    -   Utilisez `firebase deploy --only functions` pour déployer les fonctions.
+    -   Connectez-vous à Firebase avec `firebase login` si ce n'est pas déjà fait.
+    -   Pour le développement local, ce projet est configuré pour utiliser les **Firebase Emulators**.
+    -   Lancez les émulateurs avec la commande : `firebase emulators:start`
+    -   Cette commande utilisera la configuration définie dans `firebase.json` à la racine du projet. Les services principaux (Auth, Firestore, Functions) sont configurés pour utiliser les ports suivants :
+        -   Auth: `localhost:9099`
+        -   Firestore: `localhost:8092`
+        -   Functions: `localhost:5001`
+        -   Emulator UI: `localhost:4000` (par défaut)
+    -   L'application frontend (quand lancée avec `npm run dev`) se connectera automatiquement à ces émulateurs.
+    -   Si vous avez des Cloud Functions dans un dossier `functions` (par exemple), assurez-vous d'installer leurs dépendances (`npm install` dans le dossier `functions`) avant de lancer les émulateurs.
+
+3.  **Déploiement du Backend (Cloud Functions) :**
+    -   Pour déployer vos fonctions sur Firebase (environnement de production ou de test distant) :
+        -   Naviguez vers le dossier contenant vos fonctions (ex: `functions`).
+        -   Exécutez `npm install` si nécessaire.
+        -   Utilisez `firebase deploy --only functions` pour déployer les fonctions.
 
 ## 5.2. Principes Architecturaux Clés
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,63 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8092
+    },
+    "functions": {
+      "port": 5001
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "hosting": {
+      "port": 5000
+    },
+    "storage": {
+      "port": 9199
+    },
+    "database": {
+      "port": 9000
+    }
+  },
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" run lint",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ],
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
+  },
+  "hosting": {
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/src/components/GrimoireVivant.tsx
+++ b/src/components/GrimoireVivant.tsx
@@ -133,7 +133,11 @@ const GrimoireVivant: React.FC = () => {
       console.error("Error fetching spell mastery data:", error);
       setFirestoreError(error); // Set the new error state
       setIsLoading(false);
-      addToast('Erreur de connexion au Grimoire.', 'error'); // Keep existing toast
+      if (import.meta.env.DEV) {
+        addToast("Erreur Grimoire (Dev): Vérifiez l'émulateur Firestore (port 8092).", 'error', 10000);
+      } else {
+        addToast('Erreur de connexion au Grimoire.', 'error');
+      }
     });
 
     // Initial check for offline data if user is already offline
@@ -242,16 +246,28 @@ const GrimoireVivant: React.FC = () => {
   }
 
   if (firestoreError) {
+    const isDev = import.meta.env.DEV;
     return (
       <div className="grimoire-container error-container" style={{ padding: '20px', textAlign: 'center' }}>
-        <h3>Grimoire Temporarily Unavailable</h3>
-        <p>We encountered an issue loading your spell mastery data.</p>
-        <p>This might be due to a connection problem or account access restrictions.</p>
-        <p>Please try refreshing the page or check again later.</p>
-        {/* For developers: more specific error info can be logged or displayed conditionally */}
-        {import.meta.env.DEV && firestoreError.message && (
+        <h3>{isDev ? "Grimoire Connection Error (Development)" : "Grimoire Temporarily Unavailable"}</h3>
+        {isDev ? (
+          <>
+            <p>Failed to connect to Firestore to load your spell mastery data.</p>
+            <p><strong>Please ensure the Firebase emulators, especially Firestore, are running.</strong></p>
+            <p>The application expects the Firestore emulator on port <strong>8092</strong>.</p>
+            <p>You can typically start them with: <code>firebase emulators:start</code></p>
+            <p>If emulators are running, check your network configuration and Firestore security rules.</p>
+          </>
+        ) : (
+          <>
+            <p>We encountered an issue loading your spell mastery data.</p>
+            <p>This might be due to a connection problem or account access restrictions.</p>
+            <p>Please try refreshing the page or check again later.</p>
+          </>
+        )}
+        {firestoreError.message && (
           <p style={{ fontSize: '0.8em', color: 'grey', marginTop: '10px' }}>
-            <i>Developer Info: {firestoreError.message} (Code: {firestoreError.code})</i>
+            <i>Error Details: {firestoreError.message} (Code: {firestoreError.code})</i>
           </p>
         )}
       </div>


### PR DESCRIPTION
- Add firebase.json to standardize emulator port configurations, setting Firestore to 8092, Auth to 9099, and Functions to 5001.
- Enhance error handling in GrimoireVivant.tsx:
    - Display developer-specific toast for Firestore connection errors in DEV mode, pointing to emulator on port 8092.
    - Provide detailed error messages in the component UI during DEV mode, guiding users to check emulators.
- Update docs/05_Guide_Developpeur.md to include comprehensive instructions for setting up and running Firebase emulators via `firebase emulators:start`, referencing firebase.json and the specified ports.