### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/FoodFeastScene.tsx
+++ b/FoodFeastScene.tsx
@@ -1,8 +1,9 @@
 // FoodFeastScene.tsx
 import React, { useState, useEffect } from 'react';
 // Assuming foodApi.ts is in the same directory & MOCK_FOOD_ITEMS is exported
-import { FoodGameData, getFoodGameData, MOCK_FOOD_ITEMS } from './foodApi';
-import soundService from './services/soundService';
+import type { FoodGameData, FoodGameSubmitResult, FoodGameRoundResult, FoodItem } from './foodApi';
+import { getFoodGameData, MOCK_FOOD_ITEMS, submitFoodGameResults } from './foodApi';
+import soundService from './src/services/soundService';
 
 interface FoodFeastSceneProps {
   // Define props if any, e.g., onGameComplete
@@ -25,7 +26,7 @@ const FoodFeastScene: React.FC<FoodFeastSceneProps> = () => {
   const [isAnswered, setIsAnswered] = useState<boolean>(false);
   const [questionsAnswered, setQuestionsAnswered] = useState<number>(0);
   const [isRoundOver, setIsRoundOver] = useState<boolean>(false);
-  const [submissionResult, setSubmissionResult] = useState<api.FoodGameSubmitResult | null>(null);
+  const [submissionResult, setSubmissionResult] = useState<FoodGameSubmitResult | null>(null);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
 
@@ -34,12 +35,12 @@ const FoodFeastScene: React.FC<FoodFeastSceneProps> = () => {
   const handleGameEnd = async () => {
     setIsSubmitting(true);
     try {
-      const roundResult: api.FoodGameRoundResult = {
+      const roundResult: FoodGameRoundResult = {
         score,
         correctAnswers: score, // Assuming 1 point per correct answer
         totalQuestions: QUESTIONS_PER_ROUND,
       };
-      const result = await api.submitFoodGameResults(roundResult);
+      const result = await submitFoodGameResults(roundResult);
       setSubmissionResult(result);
     } catch (e) {
       console.error("Failed to submit game results:", e);
@@ -121,7 +122,7 @@ const FoodFeastScene: React.FC<FoodFeastSceneProps> = () => {
     }
 
     // Play pronunciation sound of the selected option (if available and desired)
-    const clickedFoodItemDetails = MOCK_FOOD_ITEMS.find(item => item.name === selectedOption); // Assuming MOCK_FOOD_ITEMS is accessible or options have pronunciation URLs
+    const clickedFoodItemDetails = MOCK_FOOD_ITEMS.find((item: FoodItem) => item.name === selectedOption); // Assuming MOCK_FOOD_ITEMS is accessible or options have pronunciation URLs
     if (clickedFoodItemDetails?.pronunciationUrl) {
        soundService.playSound(clickedFoodItemDetails.pronunciationUrl);
     }

--- a/LostPoemScene.tsx
+++ b/LostPoemScene.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { PoemPuzzle, PoemLine, getPoemPuzzleData } from './poemApi'; // Assuming poemApi.ts is in the same directory
+import type { PoemPuzzle, PoemLine, PoemSubmitResult } from './poemApi'; // Assuming poemApi.ts is in the same directory
+import { getPoemPuzzleData, submitPoemResults } from './poemApi'; // Assuming poemApi.ts is in the same directory
 
 interface LostPoemSceneProps {
   // Props if any, e.g., onGameComplete
@@ -13,7 +14,7 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = () => {
   const [selectedWord, setSelectedWord] = useState<{ word: string; fromBank: boolean; originalIndex?: number } | null>(null);
   const [feedback, setFeedback] = useState<('correct' | 'incorrect' | 'empty' | null)[]>([]);
   const [submitted, setSubmitted] = useState<boolean>(false);
-  const [submitResult, setSubmitResult] = useState<api.PoemSubmitResult | null>(null);
+  const [submitResult, setSubmitResult] = useState<PoemSubmitResult | null>(null);
 
 
   useEffect(() => {
@@ -96,7 +97,7 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = () => {
     setFeedback(newFeedback);
 
     try {
-      const result = await api.submitPoemResults(poemData.id, filledSlots);
+      const result = await submitPoemResults(poemData.id, filledSlots);
       setSubmitResult(result);
       // console.log("Poem submitted, result:", result);
     } catch (e) {

--- a/NamdaemunMarketScene.tsx
+++ b/NamdaemunMarketScene.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { NamdaemunMarketSceneProps, Item } from './src/types';
+import type { NamdaemunMarketSceneProps, Item } from './src/types';
 
 // Assuming Tone.js might be globally available or via import * as Tone from 'tone';
 // For robust sound, proper Tone.js setup (like Tone.start()) in the parent GamePage is recommended.

--- a/foodApi.ts
+++ b/foodApi.ts
@@ -33,7 +33,7 @@ export interface FoodGameSubmitResult {
 
 // --- Mock Data ---
 
-const MOCK_FOOD_ITEMS: FoodItem[] = [
+export const MOCK_FOOD_ITEMS: FoodItem[] = [
   { id: "ramyeon_01", name: "라면", imageUrl: "/assets/images/foods/ramyeon.jpg", imageAlt: "Image de Ramyeon", pronunciationUrl: "/assets/sounds/foods/ramyeon.mp3" },
   { id: "kimchi_01", name: "김치", imageUrl: "/assets/images/foods/kimchi.jpg", imageAlt: "Image de Kimchi", pronunciationUrl: "/assets/sounds/foods/kimchi.mp3" },
   { id: "bibimbap_01", name: "비빔밥", imageUrl: "/assets/images/foods/bibimbap.jpg", imageAlt: "Image de Bibimbap", pronunciationUrl: "/assets/sounds/foods/bibimbap.mp3" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7997,6 +7997,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/GamePage.tsx
+++ b/src/GamePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import NamdaemunMarketScene from '../NamdaemunMarketScene';
-import { GameRoundData, Item } from './types';
+import type { GameRoundData, Item } from './types';
 import { getNamdaemunGameData, submitNamdaemunResults } from './gameData';
 
 const TOTAL_ROUNDS_NAMDAEMUN = 5; // Example: 5 rounds for the mini-game

--- a/src/gameData.ts
+++ b/src/gameData.ts
@@ -1,4 +1,4 @@
-import { GameRoundData, Item } from './types';
+import type { GameRoundData, Item } from './types';
 
 const allItems: Item[] = [
   { id: 'apple', name: '사과', altText: "Image d'une pomme", imageUrl: 'https://placehold.co/100x100/FFDDDD/FF0000?text=사과' },


### PR DESCRIPTION
- Corrected type-only imports to use `import type`.
- Exported `MOCK_FOOD_ITEMS` from `foodApi.ts`.
- Fixed incorrect import path for `soundService` in `FoodFeastScene.tsx`.
- Resolved `api` namespace issues by using direct imports from API files.
- Added explicit type for `item` parameter in `FoodFeastScene.tsx`.
- Installed TypeScript as a dev dependency.