### PR TITLE
fix: Resolve most TS build errors

### DIFF
--- a/DokkaebiSaysScene.tsx
+++ b/DokkaebiSaysScene.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 interface DokkaebiSaysSceneProps {
   gameId: string;
-  onFinish: () => void;
+  onFinish: () => Promise<void>;
 }
 
 const DokkaebiSaysScene: React.FC<DokkaebiSaysSceneProps> = ({ gameId, onFinish }) => {

--- a/FoodFeastScene.tsx
+++ b/FoodFeastScene.tsx
@@ -6,8 +6,7 @@ import { getFoodGameData, MOCK_FOOD_ITEMS, submitFoodGameResults } from './foodA
 import soundService from './src/services/soundService';
 
 interface FoodFeastSceneProps {
-  gameId: string;
-  onFinish: () => void;
+  onFinish: () => Promise<void>;
 }
 
 // Defines the state of feedback after an answer
@@ -18,7 +17,7 @@ type FeedbackState = {
   clickedOption: string | null;
 };
 
-const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ gameId, onFinish }) => { // Added gameId and onFinish to props destructuring
+const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ onFinish }) => { // Added gameId and onFinish to props destructuring
   const [gameData, setGameData] = useState<FoodGameData | null>(null);
   const [score, setScore] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);

--- a/LostPoemScene.tsx
+++ b/LostPoemScene.tsx
@@ -3,11 +3,10 @@ import type { PoemPuzzle, PoemLine, PoemSubmitResult } from './poemApi'; // Assu
 import { getPoemPuzzleData, submitPoemResults } from './poemApi'; // Assuming poemApi.ts is in the same directory
 
 interface LostPoemSceneProps {
-  gameId: string;
-  onFinish: () => void;
+  onFinish: () => Promise<void>;
 }
 
-const LostPoemScene: React.FC<LostPoemSceneProps> = ({ gameId, onFinish }) => { // Added props here
+const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added props here
   const [poemData, setPoemData] = useState<PoemPuzzle | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);

--- a/NamdaemunMarketScene.tsx
+++ b/NamdaemunMarketScene.tsx
@@ -32,7 +32,6 @@ const playSound = (type: 'success' | 'error') => {
 };
 
 const NamdaemunMarketScene: React.FC<NamdaemunMarketSceneProps> = ({
-  gameId, // Added gameId
   onFinish, // Added onFinish
   gameData,
   score,
@@ -102,6 +101,7 @@ const NamdaemunMarketScene: React.FC<NamdaemunMarketSceneProps> = ({
   const timerBarPercentage = roundTimeLimit > 0 ? (timeLeft / roundTimeLimit) * 100 : 0;
 
   // Basic styles - ideally these would be in a CSS file or use a styling library
+  // Test comment
   const sceneStyle: React.CSSProperties = {
     fontFamily: "'Inter', 'Malgun Gothic', sans-serif", // From example
     padding: '20px',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -41,8 +41,8 @@ const router = createBrowserRouter([
           // AJOUT : La nouvelle route pour la salle d'attente
           { path: 'waiting-room/:gameId', element: <WaitingRoomPage /> },
           { path: 'game/:gameId', element: <GamePage /> },
-          { path: 'lost-poem', element: <LostPoemScene /> },
-          { path: 'food-feast', element: <FoodFeastScene /> }, // New route for FoodFeastScene
+          { path: 'lost-poem', element: <LostPoemScene onFinish={async () => console.log('LostPoemScene finished (dev route)')} /> },
+          { path: 'food-feast', element: <FoodFeastScene onFinish={async () => console.log('FoodFeastScene finished (dev route)')} /> }, // New route for FoodFeastScene
         ],
       },
     ],

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -243,11 +243,11 @@ const GamePage: React.FC = () => {
 
     switch (game.currentMiniGame) {
       case 'FOOD_FEAST':
-        return <FoodFeastScene gameId={gameId} onFinish={handleMiniGameFinish} />;
+        return <FoodFeastScene onFinish={handleMiniGameFinish} />;
       case 'DOKKAEBI_SAYS':
         return <DokkaebiSaysScene gameId={gameId} onFinish={handleMiniGameFinish} />;
       case 'LOST_POEM':
-        return <LostPoemScene gameId={gameId} onFinish={handleMiniGameFinish} />;
+        return <LostPoemScene onFinish={handleMiniGameFinish} />;
       case 'NAMDAEMUN_MARKET':
         // NamdaemunMarketScene has more complex props.
         // It requires gameData for the current round, score management, etc.
@@ -283,7 +283,6 @@ const GamePage: React.FC = () => {
           choices: [{ id: '1', name: '사과', altText: '사과', imageUrl: '' }],
         };
         return <NamdaemunMarketScene
-                  gameId={gameId}
                   onFinish={handleMiniGameFinish}
                   gameData={dummyNamdaemunGameData}
                   score={0}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,7 @@ export interface GameRoundData {
 }
 
 export interface NamdaemunMarketSceneProps {
-  gameId: string; // Added gameId
-  onFinish: () => void; // Added onFinish for when the entire mini-game session is over
+  onFinish: () => Promise<void>; // Added onFinish for when the entire mini-game session is over
   gameData: GameRoundData; // This is for a single round
   score: number; // Current total score for the mini-game
   onCorrectChoice: (item: Item) => void; // Callback for correct choice in a round
@@ -41,7 +40,7 @@ export interface NamdaemunGameData {
 // export declare function getNamdaemunGameData(): Promise<NamdaemunGameData>;
 // export declare function submitNamdaemunResults(score: number): Promise<void>;
 
-// For the test file, we might need to refine this later.
+// For the test file, we might need to refine this later. // Test comment
 // The tests currently imply a simpler structure being passed or available.
 // Let's adjust based on the test structure for now.
 


### PR DESCRIPTION
- Removed unused 'gameId' prop from FoodFeastScene, LostPoemScene, and NamdaemunMarketScene.
- Updated 'onFinish' prop types to Promise<void> for scenes called with async handler.
- Added 'onFinish' handlers for dev routes in main.tsx.

Note: One TS error persists in GamePage.tsx regarding a missing 'onFinish' prop for NamdaemunMarketScene, despite the prop appearing to be correctly passed.