### PR TITLE
Fix: Add onFinish prop to NamdaemunMarketScene in GamePage

### DIFF
--- a/NamdaemunMarketScene.test.tsx
+++ b/NamdaemunMarketScene.test.tsx
@@ -9,6 +9,7 @@ import { GameRoundData } from './src/types';
 const mockOnCorrectChoice = vi.fn();
 const mockOnIncorrectChoice = vi.fn();
 const mockOnRoundTimeout = vi.fn();
+const mockOnFinish = vi.fn(); // Added mock for onFinish
 
 const ROUND_TIME_LIMIT = 15; // Match default in GamePage for consistency if used
 
@@ -21,6 +22,7 @@ describe('NamdaemunMarketScene', () => {
     mockOnCorrectChoice.mockClear();
     mockOnIncorrectChoice.mockClear();
     mockOnRoundTimeout.mockClear();
+    mockOnFinish.mockClear(); // Clear onFinish mock
   });
 
   afterEach(() => {
@@ -37,6 +39,7 @@ describe('NamdaemunMarketScene', () => {
         onIncorrectChoice={mockOnIncorrectChoice}
         roundTimeLimit={timeLimit}
         onRoundTimeout={mockOnRoundTimeout}
+        onFinish={mockOnFinish} // Added onFinish prop
       />
     );
   };

--- a/src/GamePage.tsx
+++ b/src/GamePage.tsx
@@ -63,6 +63,15 @@ const GamePage: React.FC = () => {
     // Reset other game page states if any
   }
 
+  const handleNamdaemunFinish = async (): Promise<void> => {
+    setCurrentMiniGame('none');
+    setShowNamdaemunEndScreen(true);
+    // If there's any specific cleanup or finalization needed when NamdaemunMarketScene calls onFinish,
+    // it can be added here. For example, ensuring results are submitted if not already.
+    // await submitNamdaemunResults(namdaemunScore); // This is already in advanceToNextRound
+    console.log("Namdaemun Market mini-game finished and onFinish called.");
+  };
+
   if (currentMiniGame === 'namdaemun' && namdaemunGameData) {
     return (
       <NamdaemunMarketScene
@@ -72,6 +81,7 @@ const GamePage: React.FC = () => {
         onIncorrectChoice={handleIncorrectChoice}
         roundTimeLimit={ROUND_TIME_LIMIT_SECONDS}
         onRoundTimeout={handleRoundTimeout} // Or directly call advanceToNextRound if that's the only action
+        onFinish={handleNamdaemunFinish}
       />
     );
   }


### PR DESCRIPTION
- Resolved TypeScript error TS2741 where NamdaemunMarketScene component was missing the required 'onFinish' prop.
- Added handleNamdaemunFinish function in GamePage.tsx to serve as the callback.
- Updated NamdaemunMarketScene.test.tsx to include a mock for the new onFinish prop.

Note: Existing timeouts in NamdaemunMarketScene.test.tsx persist and appear unrelated to this specific prop addition, likely stemming from async operations in getNamdaemunGameData or timer mocking.