### PR TITLE
FEAT: Display definition in ReviewSession

### DIFF
--- a/src/components/ReviewSession.tsx
+++ b/src/components/ReviewSession.tsx
@@ -111,11 +111,11 @@ const ReviewSession: React.FC<ReviewSessionProps> = ({ reviewItems, onSessionEnd
           {currentItem.word || currentItem.spellId || 'Mot/Sort à réviser'}
         </div>
         <div className={`review-answer ${isRevealed ? 'visible' : ''}`}>
-          {/* This is a placeholder. The actual "answer" would depend on what needs to be recalled.
-              For a spell, it might be its effect, components, or incantation.
-              For now, we'll just use a generic placeholder. */}
-          <p>Signification/Détails de la rune : "{currentItem.word || currentItem.spellId}"</p>
-          {/* Example: <p>Effet: {currentItem.effectDescription}</p> */}
+          {currentItem.definition ? (
+            <p>{currentItem.definition}</p>
+          ) : (
+            <p>Définition non disponible.</p>
+          )}
         </div>
 
         {!isRevealed ? (

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -76,6 +76,7 @@ export interface SpellMasteryData {
   successfulCasts: number; // Number of times the spell has been cast successfully
   failedCasts: number; // Number of times the spell failed (e.g., due to lack of mana, target out of range)
   nextReviewDate?: number; // Unix timestamp (milliseconds) for next scheduled review
+  definition?: string; // The translation or definition of the word/spell
   // Optional: could add lastUsedTimestamp, specific spell stats, etc.
 }
 


### PR DESCRIPTION
- Updated SpellMasteryData type to include an optional 'definition' field.
- Modified ReviewSession.tsx to display the 'word' as the question and the 'definition' as the answer.
- This fulfills the requirements for TASK-FE-002, enabling the Forge des Sorts to show translations/definitions during review.