### PR TITLE
feat: Implement dynamic player level and XP calculation

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "functions",
+  "description": "Cloud Functions for Firebase",
+  "scripts": {
+    "lint": "eslint --ext .js,.ts .",
+    "build": "tsc",
+    "serve": "firebase emulators:start --only functions",
+    "shell": "firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "engines": {
+    "node": "18"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^5.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-google": "^0.14.0",
+    "typescript": "^5.0.0"
+  },
+  "private": true
+}

--- a/functions/src/data/levelExperience.ts
+++ b/functions/src/data/levelExperience.ts
@@ -1,0 +1,99 @@
+export interface LevelExperience {
+  level: number;
+  xpRequired: number; // Total XP required to reach this level from level 1 (0 XP)
+  xpForNextLevel?: number; // XP needed to get from this level to the next
+}
+
+export const levelExperienceTable: LevelExperience[] = [
+  { level: 1, xpRequired: 0 },
+  { level: 2, xpRequired: 100 },
+  { level: 3, xpRequired: 250 },
+  { level: 4, xpRequired: 500 },
+  { level: 5, xpRequired: 800 },
+  { level: 6, xpRequired: 1200 },
+  { level: 7, xpRequired: 1700 },
+  { level: 8, xpRequired: 2300 },
+  { level: 9, xpRequired: 3000 },
+  { level: 10, xpRequired: 4000 },
+  { level: 11, xpRequired: 5200 },
+  { level: 12, xpRequired: 6600 },
+  { level: 13, xpRequired: 8200 },
+  { level: 14, xpRequired: 10000 },
+  { level: 15, xpRequired: 12000 },
+  { level: 16, xpRequired: 14200 },
+  { level: 17, xpRequired: 16600 },
+  { level: 18, xpRequired: 19200 },
+  { level: 19, xpRequired: 22000 },
+  { level: 20, xpRequired: 25000 },
+  // Add more levels as needed
+];
+
+// Calculate xpForNextLevel for each entry
+for (let i = 0; i < levelExperienceTable.length; i++) {
+  if (i + 1 < levelExperienceTable.length) {
+    levelExperienceTable[i].xpForNextLevel = levelExperienceTable[i+1].xpRequired - levelExperienceTable[i].xpRequired;
+  } else {
+    // For the last defined level, xpForNextLevel can be undefined or set to a high value/Infinity
+    // or simply means "max level reached" if no further levels are planned.
+    levelExperienceTable[i].xpForNextLevel = undefined;
+  }
+}
+
+/**
+ * Gets the experience details for a given wizard level.
+ * @param level The wizard level.
+ * @returns LevelExperience object or undefined if the level is not in the table.
+ */
+export const getExperienceForLevel = (level: number): LevelExperience | undefined => {
+  return levelExperienceTable.find(l => l.level === level);
+};
+
+/**
+ * Determines the wizard level based on total experience.
+ * @param totalExperience The player's total experience points.
+ * @returns The current wizard level.
+ */
+export const getLevelFromExperience = (totalExperience: number): number => {
+  for (let i = levelExperienceTable.length - 1; i >= 0; i--) {
+    if (totalExperience >= levelExperienceTable[i].xpRequired) {
+      return levelExperienceTable[i].level;
+    }
+  }
+  return 1; // Default to level 1 if somehow totalExperience is negative or table is empty
+};
+
+/**
+ * Calculates the progress towards the next level.
+ * @param totalExperience The player's total experience.
+ * @param currentLevel The player's current wizard level.
+ * @returns Object with currentXPInLevel, xpToNextLevel, and progressPercentage, or null if max level.
+ */
+export const getLevelProgress = (totalExperience: number, currentLevel: number): {
+  currentXPInLevel: number;
+  xpForThisLevelToNext: number;
+  progressPercentage: number;
+} | null => {
+  const currentLevelData = getExperienceForLevel(currentLevel);
+  if (!currentLevelData) return null;
+
+  const xpRequiredForCurrentLevel = currentLevelData.xpRequired;
+
+  if (currentLevelData.xpForNextLevel === undefined) { // Max level or next level not defined
+    const xpInMaxLevel = totalExperience - xpRequiredForCurrentLevel;
+    return {
+      currentXPInLevel: xpInMaxLevel,
+      xpForThisLevelToNext: 0, // Or indicate it's max level differently
+      progressPercentage: 100, // Or handle as max level
+    };
+  }
+
+  const xpForThisLevelToNext = currentLevelData.xpForNextLevel;
+  const currentXPInLevel = totalExperience - xpRequiredForCurrentLevel;
+  const progressPercentage = (currentXPInLevel / xpForThisLevelToNext) * 100;
+
+  return {
+    currentXPInLevel,
+    xpForThisLevelToNext,
+    progressPercentage: Math.min(100, Math.max(0, progressPercentage)), // Clamp between 0 and 100
+  };
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,109 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { getLevelFromExperience } from "./data/levelExperience";
+
+// Initialize Firebase Admin SDK
+// This is typically done once per application instance.
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+
+interface SpellMasteryDoc {
+  masteryLevel: number;
+  // other fields might exist but are not needed for this calculation
+}
+
+/**
+ * Calculates a player's total experience and sorcerer level based on their spell mastery.
+ *
+ * Expects to be called by an authenticated user.
+ * Reads all documents from the `users/{userId}/spellMastery` subcollection.
+ * Applies the formula:
+ *  Level 1 (Découverte): 1 XP
+ *  Level 2 (Apprentissage): 5 XP
+ *  Level 3 (Maîtrise): 20 XP
+ *  Level 4 (Gravure): 50 XP
+ * Returns the totalExperience and calculated sorcererLevel.
+ */
+export const calculatePlayerLevel = functions
+  .region("europe-west1") // As seen in ProfilePage.tsx, good practice to specify region
+  .https.onCall(async (data, context) => {
+    // Check authentication
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "The function must be called while authenticated."
+      );
+    }
+
+    const userId = context.auth.uid;
+    let totalExperience = 0;
+
+    try {
+      const spellMasterySnapshot = await db
+        .collection("users")
+        .doc(userId)
+        .collection("spellMastery")
+        .get();
+
+      if (spellMasterySnapshot.empty) {
+        functions.logger.info(
+          `No spell mastery data found for user ${userId}. Returning 0 XP, level 1.`
+        );
+        // If no spells mastered, XP is 0, level is 1
+        return {
+          totalExperience: 0,
+          sorcererLevel: getLevelFromExperience(0), // Should be 1
+        };
+      }
+
+      spellMasterySnapshot.forEach((doc) => {
+        const spellData = doc.data() as SpellMasteryDoc;
+        const level = spellData.masteryLevel;
+
+        switch (level) {
+          case 1: // Découverte
+            totalExperience += 1;
+            break;
+          case 2: // Apprentissage
+            totalExperience += 5;
+            break;
+          case 3: // Maîtrise
+            totalExperience += 20;
+            break;
+          case 4: // Gravure
+            totalExperience += 50;
+            break;
+          default:
+            // Log if masteryLevel has an unexpected value, but don't add XP
+            functions.logger.warn(
+              `User ${userId}, spell ${doc.id} has unexpected masteryLevel: ${level}. No XP awarded for this spell.`
+            );
+            break;
+        }
+      });
+
+      const sorcererLevel = getLevelFromExperience(totalExperience);
+
+      functions.logger.info(
+        `User ${userId}: calculated totalExperience = ${totalExperience}, sorcererLevel = ${sorcererLevel}`
+      );
+
+      return {
+        totalExperience,
+        sorcererLevel,
+      };
+    } catch (error) {
+      functions.logger.error(
+        `Error calculating player level for user ${userId}:`,
+        error
+      );
+      throw new functions.https.HttpsError(
+        "internal",
+        "An error occurred while calculating player level.",
+        error
+      );
+    }
+  });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2021",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "baseUrl": ".", // Allows absolute paths from src
+    "paths": {
+      "*": ["node_modules/*"],
+      "@/*": ["src/*"] // Optional: if you want to use @/ for src folder
+    }
+  },
+  "compileOnSave": true,
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}


### PR DESCRIPTION
- Created a new Firebase Cloud Function `calculatePlayerLevel` to compute total experience and sorcerer level based on weighted `spellMastery` levels.
- Updated `ProfilePage.tsx` to call this function and display the dynamic level/XP, replacing direct reads from the user document.
- Updated `PlayerHUD.tsx` to also call this function and display the new level/XP information in all its views (desktop, mobile compact, mobile expanded).
- Added necessary configurations for the Cloud Function (package.json, tsconfig.json) and copied `levelExperience.ts` utility into the functions directory.
- Included loading and error states for the new data fetching in UI components.