### PR TITLE
feat: Implement spectator mode for mini-games

### DIFF
--- a/DokkaebiSaysScene.tsx
+++ b/DokkaebiSaysScene.tsx
@@ -1,5 +1,7 @@
 // DokkaebiSaysScene.tsx
-import React, { useState } from 'react'; // Added useState for simple interaction
+import React, { useState, useEffect } from 'react'; // Added useState and useEffect
+import type { Game } from './src/types/game'; // Import Game type
+import { broadcastAction } from './src/services/gameService'; // Import broadcastAction
 
 // Define the structure of the challenge data passed from GamePage
 export interface DokkaebiSaysChallengeData {
@@ -9,71 +11,129 @@ export interface DokkaebiSaysChallengeData {
 }
 
 interface DokkaebiSaysSceneProps {
-  // gameId is not directly used by the scene if challenge data is self-contained
   challengeData: DokkaebiSaysChallengeData;
   onFinish: (score: number, totalQuestions: number) => Promise<void>; // Consistent with FoodFeastScene
+  isSpectator?: boolean;
+  game?: Game;
 }
 
-const DokkaebiSaysScene: React.FC<DokkaebiSaysSceneProps> = ({ challengeData, onFinish }) => {
+const DokkaebiSaysScene: React.FC<DokkaebiSaysSceneProps> = ({ challengeData, onFinish, isSpectator = false, game }) => {
   const [currentRound, setCurrentRound] = useState(0);
   const [playerScore, setPlayerScore] = useState(0);
+  const [spectatorMessage, setSpectatorMessage] = useState<string | null>(null);
+  const [isGameOver, setIsGameOver] = useState(false);
+
+
+  const activePlayer = game?.players.find(p => p.uid === game.currentPlayerId);
+  const activePlayerName = activePlayer ? activePlayer.displayName : 'Joueur actif';
+
+  // Effect for spectator mode to react to live state changes
+  useEffect(() => {
+    if (isSpectator && game?.miniGameLiveState) {
+      const { lastAction, payload } = game.miniGameLiveState;
+      if (lastAction === 'SIMULATE_ROUND_DOKKAEBI') {
+        setSpectatorMessage(`${activePlayerName} a ${payload.success ? 'réussi' : 'échoué'} le round ${payload.round + 1}.`);
+        // Update local state to reflect observed progress
+        setCurrentRound(payload.round + 1); // payload.round is 0-indexed round completed
+        if (payload.isGameOver) {
+          setIsGameOver(true);
+          setSpectatorMessage(`${activePlayerName} a terminé le défi Dokkaebi Says! Score: ${payload.finalScore}/${challengeData.totalRounds}`);
+        }
+      }
+    }
+  }, [isSpectator, game?.miniGameLiveState, activePlayerName, challengeData.totalRounds]);
 
   // Placeholder for game logic: Simulate player completing a round
-  const handleSimulateRoundComplete = (success: boolean) => {
+  const handleSimulateRoundComplete = async (success: boolean) => {
+    if (isSpectator || isGameOver) return;
+
+    let newScore = playerScore;
     if (success) {
-      setPlayerScore(prev => prev + 1);
+      newScore = playerScore + 1;
+      setPlayerScore(newScore);
     }
-    if (currentRound < challengeData.totalRounds - 1) {
-      setCurrentRound(prev => prev + 1);
+
+    const nextRound = currentRound + 1;
+    const gameIsOver = nextRound >= challengeData.totalRounds;
+
+    if (game?.id) {
+      try {
+        await broadcastAction({
+          gameId: game.id,
+          action: 'SIMULATE_ROUND_DOKKAEBI',
+          payload: { success, round: currentRound, nextRound: nextRound, isGameOver: gameIsOver, score: newScore, finalScore: gameIsOver ? newScore : undefined },
+        });
+      } catch (error) {
+        console.error("Error broadcasting action:", error);
+      }
+    }
+
+    if (gameIsOver) {
+      setIsGameOver(true);
+      onFinish(newScore, challengeData.totalRounds);
     } else {
-      // Game over, call onFinish
-      onFinish(playerScore, challengeData.totalRounds);
+      setCurrentRound(nextRound);
     }
   };
 
+  const displayRound = isSpectator && game?.miniGameLiveState?.payload?.nextRound !== undefined ? game.miniGameLiveState.payload.nextRound : currentRound;
+  const displayScore = isSpectator && game?.miniGameLiveState?.payload?.score !== undefined ? game.miniGameLiveState.payload.score : playerScore;
+
+
+  if (isGameOver) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center', border: '2px dashed green', margin: '20px' }}>
+        <h1>Dokkaebi Says Mini-Game Terminé!</h1>
+        {isSpectator ? (
+          <p>{spectatorMessage || `Défi terminé pour ${activePlayerName}. Score: ${game?.miniGameLiveState?.payload?.finalScore}/${challengeData.totalRounds}`}</p>
+        ) : (
+          <p>Votre score : {playerScore} / {challengeData.totalRounds}</p>
+        )}
+        <p>Retour au jeu principal...</p>
+      </div>
+    );
+  }
+
   return (
     <div style={{ padding: '20px', textAlign: 'center', border: '2px dashed green', margin: '20px' }}>
+      {isSpectator && (
+        <div style={{ backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '5px', marginBottom: '15px', border: '1px solid #ccc' }}>
+          Vous observez {activePlayerName}...
+        </div>
+      )}
       <h1>Dokkaebi Says Mini-Game</h1>
       <p>Instructions: Suivez la séquence du Dokkaebi!</p>
 
-      {challengeData && challengeData.sequence && (
+      {challengeData && ( // Removed challengeData.sequence check as it's not used in display for this placeholder
         <div>
-          <p>Séquence actuelle (pour test): {challengeData.sequence.join(', ')}</p>
-          <p>Round: {currentRound + 1} / {challengeData.totalRounds}</p>
-          <p>Score: {playerScore}</p>
+          {/* <p>Séquence actuelle (pour test): {challengeData.sequence.join(', ')}</p> */}
+          <p>Round: {displayRound + 1} / {challengeData.totalRounds}</p>
+          <p>Score: {displayScore}</p>
         </div>
       )}
+      {isSpectator && spectatorMessage && <p style={{ fontStyle: 'italic', marginTop: '10px' }}>{spectatorMessage}</p>}
 
-      {currentRound < challengeData.totalRounds ? (
+      {displayRound < challengeData.totalRounds && !isGameOver ? (
         <div style={{marginTop: '20px'}}>
           <p>Simulez le round:</p>
           <button
             onClick={() => handleSimulateRoundComplete(true)}
-            style={{ padding: '10px 15px', fontSize: '14px', cursor: 'pointer', marginRight: '10px', backgroundColor: 'lightgreen' }}
+            style={{ padding: '10px 15px', fontSize: '14px', cursor: (isSpectator || isGameOver) ? 'default' : 'pointer', marginRight: '10px', backgroundColor: 'lightgreen', pointerEvents: (isSpectator || isGameOver) ? 'none' : 'auto' }}
+            disabled={isSpectator || isGameOver}
           >
             Réussir le round
           </button>
           <button
             onClick={() => handleSimulateRoundComplete(false)}
-            style={{ padding: '10px 15px', fontSize: '14px', cursor: 'pointer', backgroundColor: 'lightcoral' }}
+            style={{ padding: '10px 15px', fontSize: '14px', cursor: (isSpectator || isGameOver) ? 'default' : 'pointer', backgroundColor: 'lightcoral', pointerEvents: (isSpectator || isGameOver) ? 'none' : 'auto' }}
+            disabled={isSpectator || isGameOver}
           >
             Échouer le round
           </button>
         </div>
       ) : (
-        <p style={{marginTop: '20px', fontWeight: 'bold'}}>Défi Dokkaebi terminé! En attente de la suite...</p>
+         !isGameOver && <p style={{marginTop: '20px', fontWeight: 'bold'}}>Défi Dokkaebi terminé! En attente de la suite...</p>
       )}
-
-      {/* The old direct finish button is replaced by game logic progression */}
-      {/*
-      <button
-        onClick={() => onFinish(playerScore, challengeData.totalRounds)}
-        style={{ padding: '10px 20px', fontSize: '16px', cursor: 'pointer', marginTop: '30px' }}
-        disabled={currentRound < challengeData.totalRounds} // Disable if game not finished
-      >
-        Terminer le Mini-Jeu (Score Actuel)
-      </button>
-      */}
     </div>
   );
 };

--- a/FoodFeastScene.tsx
+++ b/FoodFeastScene.tsx
@@ -5,6 +5,12 @@ import { MOCK_FOOD_ITEMS } from './foodApi'; // Assuming FoodItem type is also h
 import soundService from './src/services/soundService';
 import type { FoodItem } from './foodApi'; // Ensure FoodItem is imported if not part of ChallengeData structure directly
 
+import { MOCK_FOOD_ITEMS } from './foodApi'; // Assuming FoodItem type is also here or defined below
+import soundService from './src/services/soundService';
+import type { FoodItem } from './foodApi'; // Ensure FoodItem is imported if not part of ChallengeData structure directly
+import type { Game } from './src/types/game'; // Import Game type
+import { broadcastAction } from './src/services/gameService'; // Import broadcastAction
+
 // Define the structure of the challenge data passed from GamePage
 // This should align with what `currentChallengeData` will hold for this mini-game
 export interface FoodFeastChallengeData {
@@ -23,6 +29,8 @@ export interface FoodGameQuestion {
 interface FoodFeastSceneProps {
   challengeData: FoodFeastChallengeData;
   onFinish: (score: number, totalQuestions: number) => Promise<void>; // Pass score and total to onFinish
+  isSpectator?: boolean;
+  game?: Game;
 }
 
 // Defines the state of feedback after an answer
@@ -33,28 +41,65 @@ type FeedbackState = {
   clickedOption: string | null;
 };
 
-const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ challengeData, onFinish }) => {
+const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ challengeData, onFinish, isSpectator = false, game }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(0);
   const [score, setScore] = useState<number>(0);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [isAnswered, setIsAnswered] = useState<boolean>(false); // If the current question has been answered
   const [isChallengeOver, setIsChallengeOver] = useState<boolean>(false);
+  const [spectatorClickedOption, setSpectatorClickedOption] = useState<string | null>(null);
 
   const totalQuestions = challengeData.questions.length;
   const currentQuestion = challengeData.questions[currentQuestionIndex];
+  const activePlayer = game?.players.find(p => p.uid === game.currentPlayerId);
+  const activePlayerName = activePlayer ? activePlayer.displayName : 'Joueur actif';
 
   // Effect to play sound for new question if pronunciationUrl is available
   useEffect(() => {
-    if (currentQuestion?.foodItem.pronunciationUrl) {
+    if (!isSpectator && currentQuestion?.foodItem.pronunciationUrl) {
       soundService.playSound(currentQuestion.foodItem.pronunciationUrl);
-    } else if (currentQuestion) {
+    } else if (!isSpectator && currentQuestion) {
       // Fallback sound if specific pronunciation isn't available but question exists
       soundService.playSound('new_question_default');
     }
     // Reset feedback and answered state when question changes
     setFeedback(null);
     setIsAnswered(false);
-  }, [currentQuestionIndex, currentQuestion]);
+    setSpectatorClickedOption(null);
+  }, [currentQuestionIndex, currentQuestion, isSpectator]);
+
+  // Effect for spectator mode to react to live state changes
+  useEffect(() => {
+    if (isSpectator && game?.miniGameLiveState) {
+      const { lastAction, payload } = game.miniGameLiveState;
+      if (lastAction === 'ANSWER_CLICKED' && payload?.answer) {
+        setSpectatorClickedOption(payload.answer);
+        // Simulate feedback for spectator
+        const isCorrect = payload.answer === currentQuestion?.correctAnswer;
+        setFeedback({
+          message: isCorrect ? "L'autre joueur a choisi correctement!" : `L'autre joueur a choisi ${payload.answer}. La bonne réponse était: ${currentQuestion?.correctAnswer}`,
+          isCorrect,
+          show: true,
+          clickedOption: payload.answer,
+        });
+        setIsAnswered(true); // Mark as answered to show feedback styling
+
+        // Potentially advance question for spectator after a delay
+        setTimeout(() => {
+          // Check if this logic aligns with how active player advances
+           if (currentQuestionIndex < totalQuestions - 1) {
+            // This might need to be driven by a state update rather than direct advancement
+            // setCurrentQuestionIndex(prevIndex => prevIndex + 1);
+            // For now, let the active player's progression dictate the spectator's view via game state updates
+            // or assume the game state itself will soon reflect the next question for all.
+            // If not, a more robust solution would be to listen for 'NEXT_QUESTION' action.
+          } else {
+            // setIsChallengeOver(true); // Let onFinish handle this
+          }
+        }, 2000);
+      }
+    }
+  }, [isSpectator, game?.miniGameLiveState, currentQuestion, currentQuestionIndex, totalQuestions]);
 
 
   const advanceToNextQuestion = () => {
@@ -62,15 +107,30 @@ const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ challengeData, onFinish
       setCurrentQuestionIndex(prevIndex => prevIndex + 1);
     } else {
       setIsChallengeOver(true);
-      onFinish(score, totalQuestions); // Call onFinish with final score
+      if (!isSpectator) {
+        onFinish(score, totalQuestions); // Call onFinish with final score for active player
+      }
     }
   };
 
-  const handleOptionClick = (selectedOption: string) => {
-    if (!currentQuestion || isAnswered) return;
+  const handleOptionClick = async (selectedOption: string) => {
+    if (!currentQuestion || isAnswered || isSpectator) return;
 
     setIsAnswered(true);
     const isCorrect = selectedOption === currentQuestion.correctAnswer;
+
+    if (game?.id) {
+      try {
+        await broadcastAction({
+          gameId: game.id,
+          action: 'ANSWER_CLICKED',
+          payload: { answer: selectedOption, questionIndex: currentQuestionIndex },
+        });
+      } catch (error) {
+        console.error("Error broadcasting action:", error);
+        // Handle error, maybe show a message to the user
+      }
+    }
 
     if (isCorrect) {
       setScore(prevScore => prevScore + 1);
@@ -97,26 +157,32 @@ const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ challengeData, onFinish
   };
 
   if (isChallengeOver) {
+    // Spectators will see this when the game state updates to show challenge is over for active player
     return (
       <div className="food-feast-scene" style={{ padding: '20px', fontFamily: 'Arial, sans-serif', textAlign: 'center' }}>
-        <h2>Défi Terminé!</h2>
-        <p style={{fontSize: '1.2em', margin: '20px'}}>Votre score : {score} / {totalQuestions}</p>
-        {/* The onFinish prop is called, GamePage will handle exiting/next steps */}
+        <h2>Défi Terminé{isSpectator ? ` pour ${activePlayerName}` : ''}!</h2>
+        {!isSpectator && <p style={{fontSize: '1.2em', margin: '20px'}}>Votre score : {score} / {totalQuestions}</p>}
+        {isSpectator && game?.miniGameLiveState?.payload?.finalScore !== undefined && (
+            <p style={{fontSize: '1.2em', margin: '20px'}}>Score de {activePlayerName}: {game.miniGameLiveState.payload.finalScore} / {totalQuestions}</p>
+        )}
         <p>Retour au jeu principal...</p>
       </div>
     );
   }
 
   if (!currentQuestion) {
-    // This case should ideally not be reached if challengeData is validated upstream
-    // or if isChallengeOver is handled correctly.
-    return <div>Chargement du défi... ou défi invalide.</div>;
+    return <div>Chargement du défi...</div>;
   }
 
   return (
     <div className="food-feast-scene" style={{ padding: '20px', fontFamily: 'Arial, sans-serif', textAlign: 'center' }}>
+      {isSpectator && (
+        <div style={{ backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '5px', marginBottom: '15px', border: '1px solid #ccc' }}>
+          Vous observez {activePlayerName}...
+        </div>
+      )}
       <h2>Festin des Mots Coréens! (Question {currentQuestionIndex + 1}/{totalQuestions})</h2>
-      <div data-testid="score-display" style={{ margin: '10px', fontSize: '1.2em' }}>Score: {score}</div>
+      {!isSpectator && <div data-testid="score-display" style={{ margin: '10px', fontSize: '1.2em' }}>Score: {score}</div>}
 
       <div className="question-area" style={{ margin: '20px 0', minHeight: '310px' }}>
         <img
@@ -145,22 +211,47 @@ const FoodFeastScene: React.FC<FoodFeastSceneProps> = ({ challengeData, onFinish
 
       <div className="options-container" data-testid="options-container" style={{ display: 'flex', justifyContent: 'center', gap: '10px', flexWrap: 'wrap', marginTop: feedback?.show ? '10px' : '20px' }}>
         {currentQuestion.options.map((option, index) => {
-          let buttonStyle: React.CSSProperties = { padding: '10px 20px', fontSize: '1.1em', minWidth: '100px', cursor: isAnswered ? 'default' : 'pointer' };
-          if (isAnswered && feedback?.clickedOption === option) {
-            buttonStyle.backgroundColor = feedback.isCorrect ? 'lightgreen' : 'lightcoral';
-            buttonStyle.fontWeight = 'bold';
-          } else if (isAnswered && option === currentQuestion.correctAnswer && !feedback?.isCorrect) {
+          const isButtonDisabled = isAnswered || isSpectator;
+          let buttonStyle: React.CSSProperties = {
+            padding: '10px 20px',
+            fontSize: '1.1em',
+            minWidth: '100px',
+            cursor: isButtonDisabled ? 'default' : 'pointer',
+            pointerEvents: isSpectator ? 'none' : 'auto', // Disable clicks for spectators via CSS
+          };
+
+          // Determine the option clicked, either by active player or reflected for spectator
+          const optionClickedForDisplay = isSpectator ? spectatorClickedOption : feedback?.clickedOption;
+
+          if (isAnswered && optionClickedForDisplay === option) {
+            // Highlight based on feedback if available (e.g. active player's own feedback, or simulated for spectator)
+            if (feedback) {
+              buttonStyle.backgroundColor = feedback.isCorrect ? 'lightgreen' : 'lightcoral';
+              buttonStyle.fontWeight = 'bold';
+            } else if (isSpectator) {
+              // Fallback for spectator if feedback state isn't perfectly synced, just show selection
+              buttonStyle.backgroundColor = 'lightblue'; // Generic highlight for spectator's observed click
+              buttonStyle.fontWeight = 'bold';
+            }
+          } else if (isAnswered && option === currentQuestion.correctAnswer && feedback && !feedback.isCorrect) {
+            // If answered incorrectly, and this is the correct answer, highlight it
             buttonStyle.backgroundColor = 'lightgreen';
           } else if (isAnswered) {
             buttonStyle.opacity = 0.7;
           }
+
+          // Spectator specific highlighting if no feedback has been processed yet but an action is known
+          if (isSpectator && spectatorClickedOption === option && !feedback?.show) {
+            buttonStyle.border = '2px solid blue'; // Example: blue border for observed selection
+          }
+
 
           return (
             <button
               key={index}
               data-testid={`option-button-${option.replace(/\s+/g, '-')}`}
               onClick={() => handleOptionClick(option)}
-              disabled={isAnswered}
+              disabled={isButtonDisabled}
               style={buttonStyle}
             >
               {option}

--- a/LostPoemScene.tsx
+++ b/LostPoemScene.tsx
@@ -1,12 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import type { PoemPuzzle, PoemLine, PoemSubmitResult } from './poemApi'; // Assuming poemApi.ts is in the same directory
 import { getPoemPuzzleData, submitPoemResults } from './poemApi'; // Assuming poemApi.ts is in the same directory
+import type { Game } from './src/types/game'; // Import Game type
+import { broadcastAction } from './src/services/gameService'; // Import broadcastAction
 
 interface LostPoemSceneProps {
-  onFinish: () => Promise<void>;
+  onFinish: (score?: number, total?: number) => Promise<void>; // Adjusted for consistency, score/total optional here
+  isSpectator?: boolean;
+  game?: Game;
 }
 
-const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added props here
+const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish, isSpectator = false, game }) => {
   const [poemData, setPoemData] = useState<PoemPuzzle | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -15,7 +19,10 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
   const [feedback, setFeedback] = useState<('correct' | 'incorrect' | 'empty' | null)[]>([]);
   const [submitted, setSubmitted] = useState<boolean>(false);
   const [submitResult, setSubmitResult] = useState<PoemSubmitResult | null>(null);
+  const [spectatorMessage, setSpectatorMessage] = useState<string | null>(null);
 
+  const activePlayer = game?.players.find(p => p.uid === game.currentPlayerId);
+  const activePlayerName = activePlayer ? activePlayer.displayName : 'Joueur actif';
 
   useEffect(() => {
     getPoemPuzzleData()
@@ -32,6 +39,24 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
       });
   }, []);
 
+  // Effect for spectator mode
+  useEffect(() => {
+    if (isSpectator && game?.miniGameLiveState) {
+      const { lastAction, payload } = game.miniGameLiveState;
+      if (lastAction === 'POEM_SLOT_FILLED' && payload?.filledSlots) {
+        setFilledSlots(payload.filledSlots);
+        setSpectatorMessage(`${activePlayerName} a placé des mots.`);
+      } else if (lastAction === 'POEM_SUBMITTED' && payload?.submitResult && payload?.finalFeedback) {
+        setSubmitted(true);
+        setFeedback(payload.finalFeedback);
+        setSubmitResult(payload.submitResult);
+        setSpectatorMessage(`${activePlayerName} a soumis le poème. Score: ${payload.submitResult.score}%`);
+        // onFinish might be called by GamePage based on game state, not directly here for spectator
+      }
+    }
+  }, [isSpectator, game?.miniGameLiveState, activePlayerName]);
+
+
   if (loading) {
     return <div aria-live="polite">Chargement du poème...</div>;
   }
@@ -45,53 +70,52 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
   }
 
   const handleWordBankClick = (word: string) => {
-    // If this word is already placed in a slot, selecting it from bank effectively deselects it from slot for moving
-    // For simplicity now, bank words are just sources. If a word is selected from a slot, it can be moved to another slot or back to bank.
+    if (isSpectator || submitted) return;
     if (selectedWord?.word === word && selectedWord.fromBank) {
-      setSelectedWord(null); // Deselect if clicking the same bank word
+      setSelectedWord(null);
     } else {
       setSelectedWord({ word, fromBank: true });
     }
   };
 
   const handleSlotClick = (slotIndex: number) => {
-    if (selectedWord) { // A word is selected (either from bank or another slot)
-      const newFilledSlots = [...filledSlots];
+    if (isSpectator || submitted) return;
+
+    let newFilledSlots = [...filledSlots]; // Create a mutable copy
+
+    if (selectedWord) {
       const wordToPlace = selectedWord.word;
-
-      // If the target slot already has a word, and that word is the one currently selected (meaning we are moving it FROM this slot)
-      // then this click should ideally be to pick it up, not place. But current selectedWord state handles this.
-
-      // If the selected word was from another slot, clear that original slot
       if (!selectedWord.fromBank && typeof selectedWord.originalIndex === 'number') {
-        newFilledSlots[selectedWord.originalIndex] = null;
+        newFilledSlots[selectedWord.originalIndex] = null; // Clear original slot if moving
       }
-
-      // Place the new word in the target slot
-      newFilledSlots[slotIndex] = wordToPlace;
+      newFilledSlots[slotIndex] = wordToPlace; // Place new word
       setFilledSlots(newFilledSlots);
-      setSelectedWord(null); // Word has been placed
-    } else if (filledSlots[slotIndex]) {
-      // No word is selected, and the clicked slot has a word: pick it up
+      setSelectedWord(null);
+    } else if (filledSlots[slotIndex]) { // Pick up word from slot
       const wordInSlot = filledSlots[slotIndex]!;
       setSelectedWord({ word: wordInSlot, fromBank: false, originalIndex: slotIndex });
-      // Optionally, immediately clear it from the slot, or wait for it to be placed elsewhere.
-      // For a "move" operation, clearing it now makes sense.
-      // const newFilledSlots = [...filledSlots];
-      // newFilledSlots[slotIndex] = null;
-      // setFilledSlots(newFilledSlots);
+      // To make it feel like picking up, clear the slot immediately
+      newFilledSlots[slotIndex] = null;
+      setFilledSlots(newFilledSlots);
+    }
+
+    if (game?.id && !isSpectator) { // Broadcast action if active player
+        broadcastAction({
+            gameId: game.id,
+            action: 'POEM_SLOT_FILLED',
+            payload: { filledSlots: newFilledSlots, slotIndexClicked: slotIndex },
+        }).catch(console.error);
     }
   };
 
   const handleSubmit = async () => {
-    if (!poemData) return;
+    if (!poemData || isSpectator || submitted) return;
+
     setSubmitted(true);
-    setSelectedWord(null); // Clear selection on submit
+    setSelectedWord(null);
 
     const newFeedback = poemData.lines.map((line, index) => {
-      if (filledSlots[index] === null || filledSlots[index] === undefined) {
-        return 'empty';
-      }
+      if (filledSlots[index] === null || filledSlots[index] === undefined) return 'empty';
       return filledSlots[index] === line.correctWord ? 'correct' : 'incorrect';
     });
     setFeedback(newFeedback);
@@ -99,19 +123,32 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
     try {
       const result = await submitPoemResults(poemData.id, filledSlots);
       setSubmitResult(result);
-      // console.log("Poem submitted, result:", result);
-      onFinish(); // Call onFinish after successful submission
+      if (game?.id && !isSpectator) {
+        broadcastAction({
+          gameId: game.id,
+          action: 'POEM_SUBMITTED',
+          payload: { submitResult: result, finalFeedback: newFeedback, filledSlots },
+        }).catch(console.error);
+      }
+      onFinish(result.score, 100); // Pass score and total (assuming 100%)
     } catch (e) {
       console.error("Failed to submit poem results:", e);
-      setSubmitResult({ score: 0, message: "Erreur lors de la soumission."});
-      // Consider if onFinish() should be called even on error.
-      // For now, calling it only on success.
+      const errorResult = { score: 0, message: "Erreur lors de la soumission." };
+      setSubmitResult(errorResult);
+       if (game?.id && !isSpectator) { // Also broadcast error submission if needed
+        broadcastAction({
+          gameId: game.id,
+          action: 'POEM_SUBMITTED',
+          payload: { submitResult: errorResult, finalFeedback: newFeedback, filledSlots },
+        }).catch(console.error);
+      }
+      onFinish(errorResult.score, 100); // Still call onFinish, perhaps with error score
     }
   };
 
 
   const renderPoemLine = (line: PoemLine, index: number) => {
-    const currentWordInSlot = filledSlots[index];
+    const currentWordInSlot = filledSlots[index]; // Spectator will see this updated from game state
     const slotFeedback = feedback[index];
     const isSlotSelectedForPickup = selectedWord?.fromBank === false && selectedWord?.originalIndex === index;
 
@@ -150,8 +187,8 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
         {line.textBefore}
         <span
           data-testid={`drop-zone-${index}`}
-          onClick={!submitted ? () => handleSlotClick(index) : undefined}
-          style={slotStyle}
+          onClick={(!submitted && !isSpectator) ? () => handleSlotClick(index) : undefined}
+          style={{...slotStyle, cursor: (submitted || isSpectator) ? 'default' : 'pointer', pointerEvents: (isSpectator) ? 'none' : 'auto'}}
         >
           {currentWordInSlot || '______'}
         </span>
@@ -163,13 +200,19 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
 
   return (
     <div className="lost-poem-scene" style={{ padding: '20px', fontFamily: 'Arial, sans-serif', maxWidth: '600px', margin: 'auto' }}>
+      {isSpectator && (
+        <div style={{ backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '5px', marginBottom: '15px', border: '1px solid #ccc', textAlign: 'center' }}>
+          Vous observez {activePlayerName}...
+        </div>
+      )}
       <h2 style={{ textAlign: 'center', color: '#333' }}>{poemData.title}</h2>
 
       <div data-testid="poem-text-container" style={{ margin: '20px 0', border: '1px solid #eee', padding: '20px', borderRadius: '8px', backgroundColor: '#f9f9f9' }}>
         {poemData.lines.map(renderPoemLine)}
       </div>
+      {isSpectator && spectatorMessage && <p style={{ fontStyle: 'italic', marginTop: '10px', textAlign: 'center' }}>{spectatorMessage}</p>}
 
-      {!submitted && (
+      {!submitted && !isSpectator && (
         <div data-testid="word-bank-container" style={{ marginTop: '30px', padding: '15px', border: '1px solid #ccc', borderRadius: '8px', backgroundColor: '#f9f9f9' }}>
           <h3 style={{ marginTop: 0, marginBottom: '15px', color: '#555' }}>Banque de mots :</h3>
           {selectedWord && <p style={{fontStyle: 'italic', color: '#007bff'}}>Mot sélectionné : <strong>{selectedWord.word}</strong> (Cliquez sur un espace vide pour le placer)</p>}
@@ -179,16 +222,17 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
                 key={idx}
                 data-testid={`word-bank-word-${word}`}
                 onClick={() => handleWordBankClick(word)}
-                disabled={submitted || (filledSlots.includes(word) && selectedWord?.word !== word)}
+                disabled={isSpectator || submitted || (filledSlots.includes(word) && selectedWord?.word !== word)}
                 style={{
                   padding: '8px 15px',
-                  border: selectedWord?.word === word && selectedWord.fromBank && !submitted ? '2px solid #007bff' : '1px solid #ddd',
+                  border: selectedWord?.word === word && selectedWord.fromBank && !submitted && !isSpectator ? '2px solid #007bff' : '1px solid #ddd',
                   borderRadius: '4px',
-                  cursor: submitted ? 'default' : 'pointer',
-                  backgroundColor: submitted || filledSlots.includes(word) ? '#d3d3d3' : (selectedWord?.word === word && selectedWord.fromBank ? '#cce7ff' : 'white'),
-                  color: submitted || filledSlots.includes(word) ? '#777' : '#333',
-                  fontWeight: selectedWord?.word === word && selectedWord.fromBank && !submitted ? 'bold' : 'normal',
-                  opacity: submitted || (filledSlots.includes(word) && !(selectedWord?.word === word && !selectedWord.fromBank)) ? 0.6 : 1,
+                  cursor: (isSpectator || submitted) ? 'default' : 'pointer',
+                  backgroundColor: (isSpectator || submitted || filledSlots.includes(word)) ? '#d3d3d3' : (selectedWord?.word === word && selectedWord.fromBank ? '#cce7ff' : 'white'),
+                  color: (isSpectator || submitted || filledSlots.includes(word)) ? '#777' : '#333',
+                  fontWeight: selectedWord?.word === word && selectedWord.fromBank && !submitted && !isSpectator ? 'bold' : 'normal',
+                  opacity: (isSpectator || submitted || (filledSlots.includes(word) && !(selectedWord?.word === word && !selectedWord.fromBank))) ? 0.6 : 1,
+                   pointerEvents: isSpectator ? 'none' : 'auto',
                 }}
               >
                 {word}
@@ -197,21 +241,38 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
           </div>
         </div>
       )}
+      {/* For spectators, the word bank might be hidden or shown as read-only if desired by design */}
+      {/* Example: Show read-only word bank for spectator if the game is not submitted yet */}
+      {isSpectator && !submitted && poemData.wordBank && (
+         <div data-testid="word-bank-container-spectator" style={{ marginTop: '30px', padding: '15px', border: '1px solid #ccc', borderRadius: '8px', backgroundColor: '#e9e9e9', opacity: 0.7 }}>
+          <h3 style={{ marginTop: 0, marginBottom: '15px', color: '#555' }}>Banque de mots (Observation) :</h3>
+           <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+            {poemData.wordBank.map((word, idx) => (
+              <span key={idx} style={{ padding: '8px 15px', border: '1px solid #ddd', borderRadius: '4px', backgroundColor: filledSlots.includes(word) ? '#d3d3d3' : 'white', color: filledSlots.includes(word) ? '#777' : '#333' }}>
+                {word}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
 
       <div style={{ textAlign: 'center', marginTop: '30px' }}>
         {!submitted ? (
           <button
             data-testid="verify-button"
             onClick={handleSubmit}
+            disabled={isSpectator}
             style={{
               padding: '12px 25px',
               fontSize: '16px',
-              backgroundColor: '#4CAF50',
+              backgroundColor: (isSpectator) ? '#ccc' : '#4CAF50',
               color: 'white',
               border: 'none',
               borderRadius: '5px',
-              cursor: 'pointer',
-              boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
+              cursor: (isSpectator) ? 'default' : 'pointer',
+              boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+              pointerEvents: isSpectator ? 'none' : 'auto',
             }}
           >
             Vérifier
@@ -219,10 +280,10 @@ const LostPoemScene: React.FC<LostPoemSceneProps> = ({ onFinish }) => { // Added
         ) : (
           submitResult && (
             <div data-testid="submission-result" style={{ padding: '15px', border: `1px solid ${submitResult.score > 50 ? 'green' : 'orange'}`, borderRadius: '5px', backgroundColor: `${submitResult.score > 70 ? '#d4edda' : '#fff3cd'}` }}>
-              <h3 style={{marginTop: 0}}>Résultats :</h3>
+              <h3 style={{marginTop: 0}}>{isSpectator ? `Résultats de ${activePlayerName}` : "Résultats :"}</h3>
               <p>{submitResult.message}</p>
               <p>Score: {submitResult.score}%</p>
-              {/* Could add a button to play again or go back */}
+              {isSpectator && <p>Attente du retour au jeu principal...</p>}
             </div>
           )
         )}

--- a/NamdaemunMarketScene.tsx
+++ b/NamdaemunMarketScene.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
-import type { NamdaemunMarketSceneProps, Item } from './src/types';
+import type { NamdaemunMarketSceneProps, Item, NamdaemunGameData } from './src/types'; // Added NamdaemunGameData
+import type { Game } from './src/types/game'; // Import Game type
+import { broadcastAction } from './src/services/gameService'; // Import broadcastAction
 
 // Assuming Tone.js might be globally available or via import * as Tone from 'tone';
 // For robust sound, proper Tone.js setup (like Tone.start()) in the parent GamePage is recommended.
 declare var Tone: any; // Allow Tone to be used if loaded globally e.g. via CDN
 
-const playSound = (type: 'success' | 'error') => {
+const playSound = (type: 'success' | 'error', isSpectator: boolean) => {
+  if (isSpectator) return; // Spectators don't trigger sounds locally based on active player's actions
   try {
     if (typeof Tone !== 'undefined' && Tone.Synth) {
       if (type === 'success') {
@@ -14,14 +17,14 @@ const playSound = (type: 'success' | 'error') => {
           envelope: { attack: 0.005, decay: 0.1, sustain: 0.05, release: 0.1 },
         }).toDestination();
         synth.triggerAttackRelease('C5', '8n', Tone.now());
-        setTimeout(() => synth.dispose(), 200); // Clean up synth
+        setTimeout(() => synth.dispose(), 200);
       } else if (type === 'error') {
         const synth = new Tone.Synth({
           oscillator: { type: 'square' },
           envelope: { attack: 0.005, decay: 0.2, sustain: 0, release: 0.2 },
         }).toDestination();
         synth.triggerAttackRelease('A2', '8n', Tone.now());
-        setTimeout(() => synth.dispose(), 300); // Clean up synth
+        setTimeout(() => synth.dispose(), 300);
       }
     } else {
       console.log(`Fallback: Play ${type} sound (Tone.js not available or Synth not found)`);
@@ -31,74 +34,142 @@ const playSound = (type: 'success' | 'error') => {
   }
 };
 
-const NamdaemunMarketScene: React.FC<NamdaemunMarketSceneProps> = ({
-  onFinish, // Added onFinish
-  gameData,
-  score,
+// Modify props to include isSpectator and game (for gameId and active player name)
+interface ExtendedNamdaemunMarketSceneProps extends NamdaemunMarketSceneProps {
+  isSpectator?: boolean;
+  game?: Game; // Making game prop available for gameId and player info
+}
+
+const NamdaemunMarketScene: React.FC<ExtendedNamdaemunMarketSceneProps> = ({
+  onFinish,
+  gameData, // This is current round data
+  score,    // This is active player's current score
   onCorrectChoice,
   onIncorrectChoice,
   roundTimeLimit, // seconds
   onRoundTimeout,
+  isSpectator = false,
+  game, // game state from GamePage
 }) => {
   const [feedbackMessage, setFeedbackMessage] = useState<string>('');
-  const [isInteractable, setIsInteractable] = useState<boolean>(true);
+  const [isInteractable, setIsInteractable] = useState<boolean>(!isSpectator); // Spectators cannot interact
   const [timeLeft, setTimeLeft] = useState<number>(roundTimeLimit);
-  const [showCorrectEffect, setShowCorrectEffect] = useState<string | null>(null); // item.id for effect
+  const [showCorrectEffect, setShowCorrectEffect] = useState<string | null>(null);
+  const [spectatorAction, setSpectatorAction] = useState<{itemId: string, isCorrect: boolean} | null>(null);
+
 
   const timerIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const activePlayer = game?.players.find(p => p.uid === game.currentPlayerId);
+  const activePlayerName = activePlayer ? activePlayer.displayName : 'Joueur actif';
 
+  // Effect for timer and gameData reset
   useEffect(() => {
     setFeedbackMessage('');
-    setIsInteractable(true);
+    setIsInteractable(!isSpectator); // Ensure interactability is reset based on spectator status
     setTimeLeft(roundTimeLimit);
     setShowCorrectEffect(null);
+    setSpectatorAction(null);
 
     if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
 
-    timerIntervalRef.current = setInterval(() => {
-      setTimeLeft((prevTime) => {
-        if (prevTime <= 1) {
-          if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
-          handleTimeout();
-          return 0;
-        }
-        return prevTime - 1;
-      });
-    }, 1000);
+    // Timer should only run for the active player, or if explicitly synced for spectators
+    // For simplicity, spectator's timer might just mirror, or be less critical.
+    // The backend should ultimately decide round progression.
+    // If this scene instance is for an active player, start the timer.
+    if (!isSpectator) {
+      timerIntervalRef.current = setInterval(() => {
+        setTimeLeft((prevTime) => {
+          if (prevTime <= 1) {
+            if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
+            handleTimeout(); // Active player timed out
+            return 0;
+          }
+          return prevTime - 1;
+        });
+      }, 1000);
+    }
 
     return () => { if (timerIntervalRef.current) clearInterval(timerIntervalRef.current); };
-  }, [gameData, roundTimeLimit]);
+  }, [gameData, roundTimeLimit, isSpectator]); // Added isSpectator
 
-  const handleTimeout = () => {
-    if (!isInteractable) return;
+  // Effect for spectator mode actions
+  useEffect(() => {
+    if (isSpectator && game?.miniGameLiveState) {
+      const { lastAction, payload } = game.miniGameLiveState;
+      if (lastAction === 'NAMDAEMUN_CHOICE' && payload?.itemId && gameData) {
+        const chosenItem = gameData.choices.find(c => c.id === payload.itemId);
+        if (chosenItem) {
+            const isCorrect = chosenItem.id === gameData.customerRequest.itemWanted.id;
+            setSpectatorAction({ itemId: chosenItem.id, isCorrect });
+            setShowCorrectEffect(isCorrect ? chosenItem.id : null);
+            const wantedItemName = gameData.customerRequest.itemWanted.name;
+            setFeedbackMessage(
+                isCorrect ? `${activePlayerName} a trouvé ${wantedItemName}!` : `${activePlayerName} a choisi ${chosenItem.name}. Ce n'était pas ${wantedItemName}.`
+            );
+        }
+      } else if (lastAction === 'NAMDAEMUN_TIMEOUT') {
+          setFeedbackMessage(`Temps écoulé pour ${activePlayerName}! Il cherchait ${gameData?.customerRequest.itemWanted.name}.`);
+          setIsInteractable(false); // Ensure UI is non-interactable for spectator on timeout
+      }
+    }
+  }, [isSpectator, game?.miniGameLiveState, gameData, activePlayerName]);
+
+
+  const handleTimeout = () => { // Only called for active player
+    if (!isInteractable || isSpectator) return; // Should not be called for spectator
     setIsInteractable(false);
     const wantedItemName = gameData?.customerRequest?.itemWanted?.name || 'l\'article demandé';
     setFeedbackMessage(`Temps écoulé ! Le client voulait ${wantedItemName}.`);
-    playSound('error');
-    if (gameData) onIncorrectChoice(gameData.customerRequest.itemWanted, true);
-    onRoundTimeout();
+    playSound('error', isSpectator);
+    if (gameData) onIncorrectChoice(gameData.customerRequest.itemWanted, true); // This updates score for active player
+
+    if (game?.id) {
+      broadcastAction({
+        gameId: game.id,
+        action: 'NAMDAEMUN_TIMEOUT',
+        payload: { round: gameData?.roundNumber || 0 }, // Assuming gameData has roundNumber
+      }).catch(console.error);
+    }
+    onRoundTimeout(); // This likely triggers next round or finish for active player
   };
 
-  const handleChoiceClick = (item: Item) => {
-    if (!isInteractable || !gameData) return;
+  const handleChoiceClick = async (item: Item) => {
+    if (!isInteractable || !gameData || isSpectator) return;
 
     if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
     setIsInteractable(false);
 
-    if (item.id === gameData.customerRequest.itemWanted.id) {
+    const isCorrect = item.id === gameData.customerRequest.itemWanted.id;
+
+    if (game?.id) {
+      try {
+        await broadcastAction({
+          gameId: game.id,
+          action: 'NAMDAEMUN_CHOICE',
+          payload: { itemId: item.id, isCorrect, round: gameData?.roundNumber || 0 },
+        });
+      } catch (error) {
+        console.error("Error broadcasting Namdaemun choice:", error);
+      }
+    }
+
+    if (isCorrect) {
       setFeedbackMessage('Merci !');
-      playSound('success');
+      playSound('success', isSpectator);
       setShowCorrectEffect(item.id);
-      onCorrectChoice(item);
+      onCorrectChoice(item); // Updates score for active player
     } else {
       const wantedItemName = gameData?.customerRequest?.itemWanted?.name || 'l\'article demandé';
       setFeedbackMessage(`Oops! Ce n'est pas ${item.name}. Le client voulait ${wantedItemName}.`);
-      playSound('error');
-      onIncorrectChoice(item, false);
+      playSound('error', isSpectator);
+      onIncorrectChoice(item, false); // Updates score for active player
     }
+    // onFinish or next round logic is typically handled by onCorrectChoice/onIncorrectChoice callbacks
+    // which should eventually lead to GamePage calling onFinish for the mini-game.
   };
 
   const timerBarPercentage = roundTimeLimit > 0 ? (timeLeft / roundTimeLimit) * 100 : 0;
+  const currentScore = isSpectator ? (game?.miniGameLiveState?.payload?.currentScore ?? score) : score;
 
   // Basic styles - ideally these would be in a CSS file or use a styling library
   // Test comment
@@ -150,6 +221,11 @@ const NamdaemunMarketScene: React.FC<NamdaemunMarketSceneProps> = ({
     <>
       <style>{buttonHoverStyle}</style>
       <div style={sceneStyle}>
+        {isSpectator && (
+          <div style={{ backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '5px', marginBottom: '15px', border: '1px solid #ccc', textAlign: 'center' }}>
+            Vous observez {activePlayerName}...
+          </div>
+        )}
         <header style={{ marginBottom: '15px', paddingBottom: '10px', borderBottom: '1px solid #f3f4f6' }}> {/* gray-100 */}
           <h1 style={headerStyle}>Au Marché de Namdaemun !</h1>
         </header>
@@ -160,7 +236,7 @@ const NamdaemunMarketScene: React.FC<NamdaemunMarketSceneProps> = ({
               Temps: <span data-testid="time-left" style={{ color: timeLeft <= 5 ? '#ef4444' : '#3b82f6' }}>{timeLeft}</span>s {/* red-500 / blue-500 */}
             </div>
             <div id="scoreArea" style={{ fontSize: '20px', fontWeight: 'bold', color: '#854d0e' }}> {/* amber-700 */}
-              Score: <span data-testid="score-display">{score}</span>
+              Score {isSpectator ? `de ${activePlayerName}`: ''}: <span data-testid="score-display">{currentScore}</span>
             </div>
           </div>
 
@@ -176,41 +252,61 @@ const NamdaemunMarketScene: React.FC<NamdaemunMarketSceneProps> = ({
           )}
 
           <div id="choicesArea" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: '15px', marginBottom: '20px' }}>
-            {choices && choices.map((item) => (
-              <button
-                key={item.id}
-                className={`choice-button ${showCorrectEffect === item.id ? 'correct-choice-effect' : ''}`}
-                onClick={() => handleChoiceClick(item)}
-                disabled={!isInteractable}
-                style={buttonBaseStyle}
-              >
-                <img src={item.imageUrl || `https://placehold.co/100x100/E2E8F0/4A5568?text=${encodeURIComponent(item.name)}`} alt={item.altText} style={{ width: '100px', height: '100px', objectFit: 'cover', marginBottom: '8px', borderRadius: '6px' }} />
-                <p style={{ fontSize: '1rem', color: '#374151', margin: 0, fontWeight: 500 }}>{item.name}</p> {/* gray-700 */}
-              </button>
-            ))}
+            {choices && choices.map((item) => {
+              // Determine if this item was the one clicked by the active player (for spectator view)
+              const isSpectatorObservedClick = isSpectator && spectatorAction?.itemId === item.id;
+              const isCorrectSpectatorObservedClick = isSpectatorObservedClick && spectatorAction?.isCorrect;
+
+              let itemStyle = {...buttonBaseStyle};
+              if (isSpectator) {
+                itemStyle.pointerEvents = 'none'; // Disable clicks for spectator
+                itemStyle.cursor = 'default';
+                if (isSpectatorObservedClick) {
+                   itemStyle.border = isCorrectSpectatorObservedClick ? '3px solid #10B981' : '3px solid #ef4444'; // Green for correct, Red for incorrect
+                   itemStyle.boxShadow = isCorrectSpectatorObservedClick ? '0 0 15px rgba(16, 185, 129, 0.7)' : '0 0 15px rgba(239, 68, 68, 0.7)';
+                } else {
+                    itemStyle.opacity = 0.7; // Dim unchosen items for spectator if an action occurred
+                }
+              }
+
+              return (
+                <button
+                  key={item.id}
+                  className={`choice-button ${showCorrectEffect === item.id && !isSpectator ? 'correct-choice-effect' : ''}`}
+                  onClick={() => handleChoiceClick(item)}
+                  disabled={!isInteractable || isSpectator} // Also disable for spectator
+                  style={itemStyle}
+                >
+                  <img src={item.imageUrl || `https://placehold.co/100x100/E2E8F0/4A5568?text=${encodeURIComponent(item.name)}`} alt={item.altText} style={{ width: '100px', height: '100px', objectFit: 'cover', marginBottom: '8px', borderRadius: '6px' }} />
+                  <p style={{ fontSize: '1rem', color: '#374151', margin: 0, fontWeight: 500 }}>{item.name}</p> {/* gray-700 */}
+                </button>
+              );
+            })}
           </div>
 
-          <div data-testid="feedback-area" style={{ marginTop: '20px', textAlign: 'center', minHeight: '40px', fontWeight: '600', padding: '12px', borderRadius: '8px', fontSize: '1.1rem', color: feedbackMessage.startsWith('Merci') ? '#059669' : feedbackMessage ? '#dc2626' : 'transparent', backgroundColor: feedbackMessage ? (feedbackMessage.startsWith('Merci') ? '#d1fae5' : '#fee2e2') : 'transparent', transition: 'all 0.3s ease' }}> {/* green-600/100, red-600/100 */}
+          <div data-testid="feedback-area" style={{ marginTop: '20px', textAlign: 'center', minHeight: '40px', fontWeight: '600', padding: '12px', borderRadius: '8px', fontSize: '1.1rem', color: feedbackMessage.includes('Merci') || (spectatorAction?.isCorrect && feedbackMessage.includes(activePlayerName)) ? '#059669' : feedbackMessage ? '#dc2626' : 'transparent', backgroundColor: feedbackMessage ? (feedbackMessage.includes('Merci') || (spectatorAction?.isCorrect && feedbackMessage.includes(activePlayerName)) ? '#d1fae5' : '#fee2e2') : 'transparent', transition: 'all 0.3s ease' }}> {/* green-600/100, red-600/100 */}
             {feedbackMessage}
           </div>
 
-          {/* Temporary button to call onFinish for testing purposes */}
-          <div style={{ textAlign: 'center', marginTop: '20px' }}>
-            <button
-              onClick={onFinish}
-              style={{
-                padding: '10px 20px',
-                fontSize: '14px',
-                color: 'white',
-                backgroundColor: '#007bff',
-                border: 'none',
-                borderRadius: '5px',
-                cursor: 'pointer'
-              }}
-            >
-              Force Finish Namdaemun Market (Dev)
-            </button>
-          </div>
+          {/* Temporary button to call onFinish for testing purposes - hide for spectators */}
+          {!isSpectator && (
+            <div style={{ textAlign: 'center', marginTop: '20px' }}>
+              <button
+                onClick={onFinish}
+                style={{
+                  padding: '10px 20px',
+                  fontSize: '14px',
+                  color: 'white',
+                  backgroundColor: '#007bff',
+                  border: 'none',
+                  borderRadius: '5px',
+                  cursor: 'pointer'
+                }}
+              >
+                Force Finish Namdaemun Market (Dev)
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/src/services/gameService.tsx
+++ b/src/services/gameService.tsx
@@ -163,6 +163,33 @@ export const createGuild = async (name: string, tag: string): Promise<any> => {
   }
 };
 
+// --- Mini-Game Action Broadcasting ---
+
+interface BroadcastActionPayload {
+  gameId: string;
+  action: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: any; // Consider defining a more specific type based on possible actions
+}
+
+/**
+ * Calls the Cloud Function to broadcast a player's action in a mini-game.
+ * @param params - The data required for the action.
+ * @returns A promise that resolves when the function call is complete.
+ */
+export const broadcastAction = async (params: BroadcastActionPayload): Promise<void> => {
+  try {
+    console.log(`[CLIENT] Calling 'updateMiniGameAction' function with payload:`, params);
+    const updateMiniGameActionFunction = httpsCallable(functions, 'updateMiniGameAction');
+    await updateMiniGameActionFunction(params);
+    console.log("Cloud Function 'updateMiniGameAction' called successfully.");
+  } catch (error) {
+    console.error("Error calling updateMiniGameAction function:", error);
+    // Optionally re-throw or handle as per application's error handling strategy
+    throw error;
+  }
+};
+
 // --- Mini-Game Challenge Preparation ---
 
 interface PrepareChallengePayload {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -67,6 +67,13 @@ export interface Game {
   } | null;
   winnerId: string | null;
   createdAt: Timestamp;
+  miniGameLiveState?: MiniGameLiveState;
+}
+
+export interface MiniGameLiveState {
+  lastAction: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: any; // Define a more specific type based on possible actions
 }
 
 export interface SpellMasteryData {


### PR DESCRIPTION
This commit introduces a spectator mode for all mini-game scenes (FoodFeastScene, DokkaebiSaysScene, LostPoemScene, NamdaemunMarketScene).

Key changes:
- Added `isSpectator` and `game` props to mini-game scenes.
- Active players broadcast their actions (e.g., clicks, choices, submissions) via a new `gameService.broadcastAction` function, which calls the `updateMiniGameAction` cloud function.
- Spectators see a non-interactive version of the mini-game UI with a banner indicating the active player they are observing.
- Spectators' UIs react to changes in `game.miniGameLiveState` (updated by the backend) to mirror the active player's actions and game progression in real-time.
- Defined `MiniGameLiveState` type in `src/types/game.ts`.
- Updated `GamePage.tsx` to pass the necessary props to mini-game components.